### PR TITLE
Text indicator performance

### DIFF
--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -459,12 +459,13 @@ local function Text_SetCooldown(frame, start, duration, debuffType, texture, cou
         frame:SetScript("OnUpdate", nil)
     else
         if frame.durationTbl[1] then
+            local fmt
             if count == 0 then
-                count = ""
+                fmt, count = "%s", ""
             elseif frame.circledStackNums then
-                count = circled[count] .. " "
+                fmt, count = "%s ", circled[count] .. " "
             else
-                count = count .. " "
+                fmt = "%d "
             end
             frame:SetScript("OnUpdate", function()
                 local remain = duration-(GetTime()-start)
@@ -476,29 +477,35 @@ local function Text_SetCooldown(frame, start, duration, debuffType, texture, cou
                 elseif remain <= duration * frame.colors[2][4] then
                     frame.text:SetTextColor(frame.colors[2][1], frame.colors[2][2], frame.colors[2][3])
                 else
-                    frame.text:SetTextColor(unpack(frame.colors[1]))
+                    frame.text:SetTextColor(frame.colors[1][1], frame.colors[1][2], frame.colors[1][3])
                 end
 
                 -- format
+                local fmt2
                 if remain > 60 then
-                    remain = string.format("%dm", remain/60)
+                    fmt2, remain = fmt .. "%dm", remain/60
                 else
                     if frame.durationTbl[2] then
-                        remain = math.ceil(remain)
+                        fmt2, remain = fmt .. "%d", remain + 0.9999
+                        remain = remain < 1 and 1 or remain
                     else
                         if remain < frame.durationTbl[3] then
-                            remain = string.format("%.1f", remain)
+                            fmt2 = fmt .. "%.1f"
                         else
-                            remain = string.format("%d", remain)
+                            fmt2 = fmt .. "%d"
                         end
                     end
                 end
-
-                frame.text:SetText(count..remain)
+                frame.text:SetFormattedText(fmt2, count, remain)
             end)
         else
             count = count == 0 and 1 or count
-            count = frame.circledStackNums and circled[count] or count
+            local fmt = frame.circledStackNums and circled[count]
+            if fmt then
+                count = nil
+            else
+                fmt = "%d"
+            end
             frame:SetScript("OnUpdate", function()
                 local remain = duration-(GetTime()-start)
                 -- update color
@@ -507,10 +514,10 @@ local function Text_SetCooldown(frame, start, duration, debuffType, texture, cou
                 elseif remain <= duration * frame.colors[2][4] then
                     frame.text:SetTextColor(frame.colors[2][1], frame.colors[2][2], frame.colors[2][3])
                 else
-                    frame.text:SetTextColor(unpack(frame.colors[1]))
+                    frame.text:SetTextColor(frame.colors[1][1], frame.colors[1][2], frame.colors[1][3])
                 end
                 -- update text
-                frame.text:SetText(count)
+                frame.text:SetFormattedText(fmt, count)
             end)
 
         end

--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -460,7 +460,7 @@ local function Text_SetCooldown(frame, start, duration, debuffType, texture, cou
     else
         if frame.durationTbl[1] then
             local fmt
-            if count == 0 then
+            if count == 0 or (count == 1 and not frame.circledStackNums) then
                 fmt, count = "%s", ""
             elseif frame.circledStackNums then
                 fmt, count = "%s ", circled[count] .. " "


### PR DESCRIPTION
之前研究过，魔兽SetText时如果直接设置数字，占用CPU会高，然后如果用lua将数字转为字符串也很慢，其中format较快，tostring和""..i差不多，都很慢。后来发现暴雪自己用SetFormattedText，很快，猜测是里面可能是用c实现的，下面这个例子在我电脑上差异很大，68fps 比 102fps

unpack是顺手测了一下，差5-10帧

当然，这个是比较极端的情况，实际游戏里可能差别不大，不过改改也不麻烦，其实主要是想提一下1层的时候不显示，因为有些buff始终返回1层，比如奶骑震击暴击的层数（可能天赋能强化到2层，但没强化的时候它就返回1层而不是0层）。目前是如果没选圆圈层数，就不显示1层，选了就显示。怪怪的，你看看吧。

function U1UpdateTest(self, elapsed)
    --local count = 2 .. " " PlayerName:SetText(count .. string.format("%d", 8)) --68fps
    PlayerName:SetFormattedText("%d %d", 2, 8) --102fps
end

for i=1,10000 do
    CreateFrame("Frame"):SetScript("OnUpdate", function(self, elapsed) U1UpdateTest(self, elapsed) end)
end