### PR TITLE
Fix Full Health Color

### DIFF
--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -2019,7 +2019,7 @@ local function UnitButton_UpdateHealthMax(self)
         self.widgets.healthBar:SetMinMaxValues(0, self.states.healthMax)
     end
 
-    if Cell.vars.useGradientColor then
+    if Cell.vars.useGradientColor or Cell.vars.useFullColor then
         UnitButton_UpdateHealthColor(self)
     end
 end
@@ -2043,7 +2043,7 @@ local function UnitButton_UpdateHealth(self, diff)
         self.widgets.healthBar:SetBarValue(self.states.health)
     end
 
-    if Cell.vars.useGradientColor then
+    if Cell.vars.useGradientColor or Cell.vars.useFullColor then
         UnitButton_UpdateHealthColor(self)
     end
 

--- a/RaidFrames/UnitButton_Cata_Wrath.lua
+++ b/RaidFrames/UnitButton_Cata_Wrath.lua
@@ -1766,7 +1766,7 @@ local function UnitButton_UpdateHealthMax(self)
         self.widgets.healthBar:SetMinMaxValues(0, self.states.healthMax)
     end
 
-    if Cell.vars.useGradientColor then
+    if Cell.vars.useGradientColor or Cell.vars.useFullColor then
         UnitButton_UpdateHealthColor(self)
     end
 end
@@ -1790,7 +1790,7 @@ local function UnitButton_UpdateHealth(self, diff)
         self.widgets.healthBar:SetBarValue(self.states.health)
     end
 
-    if Cell.vars.useGradientColor then
+    if Cell.vars.useGradientColor or Cell.vars.useFullColor then
         UnitButton_UpdateHealthColor(self)
     end
 

--- a/RaidFrames/UnitButton_Vanilla.lua
+++ b/RaidFrames/UnitButton_Vanilla.lua
@@ -1666,7 +1666,7 @@ local function UnitButton_UpdateHealthMax(self)
         self.widgets.healthBar:SetMinMaxValues(0, self.states.healthMax)
     end
 
-    if Cell.vars.useGradientColor then
+    if Cell.vars.useGradientColor or Cell.vars.useFullColor then
         UnitButton_UpdateHealthColor(self)
     end
 end
@@ -1690,7 +1690,7 @@ local function UnitButton_UpdateHealth(self, diff)
         self.widgets.healthBar:SetBarValue(self.states.health)
     end
 
-    if Cell.vars.useGradientColor then
+    if Cell.vars.useGradientColor or Cell.vars.useFullColor then
         UnitButton_UpdateHealthColor(self)
     end
 


### PR DESCRIPTION
With `Enable Full Health Color` selected, the unit's health bar would always be in the chosen full health color (i.e. even at below 100% health) until the next unit button health color was triggered.

![image](https://github.com/user-attachments/assets/acac6dfa-f145-4e98-8541-09554eecf841)

This commit fixes this by triggering a health bar color update if `Cell.vars.useFullColor` is set.