### PR TITLE
Add pixel glow border to dispellable debuffs

### DIFF
--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -567,12 +567,16 @@ local function Dispels_SetDispels(self, dispelTypes)
     local found
 
     self.highlight:Hide()
+    LCG.PixelGlow_Stop(self.parent)
 
     local i = 0
     for _, dispelType in ipairs(dispelOrder) do
         local showHighlight = dispelTypes[dispelType]
         if type(showHighlight) == "boolean" then
             -- highlight
+            if not showHighlight or self.highlightType ~= "glow" then
+                LCG.PixelGlow_Stop(self.parent)
+            end
             if not found and self.highlightType ~= "none" and dispelType and showHighlight then
                 found = true
                 local r, g, b = I.GetDebuffTypeColor(dispelType)
@@ -582,8 +586,12 @@ local function Dispels_SetDispels(self, dispelTypes)
                     self.highlight:SetVertexColor(r, g, b, 1)
                 elseif self.highlightType == "gradient" or self.highlightType == "gradient-half" then
                     self.highlight:SetGradient("VERTICAL", CreateColor(r, g, b, 1), CreateColor(r, g, b, 0))
+                elseif self.highlightType == "glow" then
+                    -- Use 3 pixel thickness and offset by 1 pixel
+                    -- These are reasonable defaults but could make it configurable in future enhancement
+                    LCG.PixelGlow_Start(self.parent, {r, g, b, 1}, nil, nil, nil, 3, 1, 1)
                 end
-                self.highlight:Show()
+                if self.highlightType ~= "glow" then self.highlight:Show() end
             end
             -- icons
             if self.showIcons then
@@ -649,6 +657,7 @@ local function Dispels_UpdateHighlight(self, highlightType)
 
     if highlightType == "none" then
         self.highlight:Hide()
+        LCG.PixelGlow_Stop(self.parent)
     elseif highlightType == "gradient" then
         -- self.highlight:SetParent(self.parent.widgets.indicatorFrame)
         self.highlight:ClearAllPoints()
@@ -681,6 +690,9 @@ local function Dispels_UpdateHighlight(self, highlightType)
         self.highlight:SetTexture(Cell.vars.texture)
         self.highlight:SetDrawLayer("ARTWORK", -7)
         self.highlight:SetBlendMode("ADD")
+    elseif highlightType == "glow" then
+        LCG.PixelGlow_Stop(self.parent)
+        self.highlight:Hide()
     end
 end
 
@@ -692,6 +704,7 @@ function I.CreateDispels(parent)
 
     dispels:SetScript("OnHide", function()
         dispels.highlight:Hide()
+        LCG.PixelGlow_Stop(parent)
     end)
 
     dispels.highlight = parent.widgets.midLevelFrame:CreateTexture(parent:GetName().."DispelHighlight")

--- a/Modules/Indicators.lua
+++ b/Modules/Indicators.lua
@@ -368,6 +368,7 @@ local function InitIndicator(indicatorName)
             local found
 
             self.highlight:Hide()
+            LCG.PixelGlow_Stop(self.parent)
 
             local i = 1
             for dispelType, showHighlight in pairs(dispelTypes) do
@@ -381,8 +382,13 @@ local function InitIndicator(indicatorName)
                         self.highlight:SetVertexColor(r, g, b, 1)
                     elseif self.highlightType == "gradient" or self.highlightType == "gradient-half" then
                         self.highlight:SetGradient("VERTICAL", CreateColor(r, g, b, 1), CreateColor(r, g, b, 0))
+                    elseif self.highlightType == "glow" then
+                        -- Use 3 pixel thickness and offset by 1 pixel
+                        -- These are reasonable defaults but could make it configurable in future enhancement
+                        LCG.PixelGlow_Start(self.parent, {r, g, b, 1}, nil, nil, nil, 3, 1, 1)
+                        self.highlight:Hide()
                     end
-                    if indicator.isVisible then self.highlight:Show() end
+                    if indicator.isVisible and self.highlightType ~= "glow" then self.highlight:Show() end
                 end
                 -- icons
                 if self.showIcons then

--- a/Widgets/Widgets_IndicatorSettings.lua
+++ b/Widgets/Widgets_IndicatorSettings.lua
@@ -5473,6 +5473,13 @@ local function CreateSetting_HighlightType(parent)
                     widget.func("current+")
                 end,
             },
+            {
+                ["text"] = L["Glow - Pixel"],
+                ["value"] = "glow",
+                ["onClick"] = function()
+                    widget.func("glow")
+                end,
+            },
         })
 
         widget.highlightTypeText = widget:CreateFontString(nil, "OVERLAY", font_name)


### PR DESCRIPTION
Hello,

First off thank you for creating this amazing addon. I've been using it the last few months and noticed that users are not able to add a border for dispellable debuffs. This type of setting is widely used in other raid frame addons such as Grid2 and as such is a familiar way for users to interact with dispellable debuffs.

I'd like to merge this commit in that allows users to select pixel glow for Dispels in the Indicators panel. Below are screenshots of the functionality.

![pixel_glow_frame](https://github.com/user-attachments/assets/d12f0b8f-26b6-4757-b059-4ca5508f0c66)
![pixel_glow_preview](https://github.com/user-attachments/assets/2728a8bd-7668-4034-9924-f18d18a3e497)

I have tested the following scenarios
* Selecting pixel glow removes other highlight types from the preview panel
* Navigating to a different Indicator removes the pixel glow from the preview panel
* Show All displays the pixel glow
* Turning off Show All removes the pixel glow
* Pixel glow shows on frame when a dispellable debuff is applied to player
* Pixel glow is removed from frame when debuff is removed

Given this is my first commit to the repo, please let me know if anything looks incorrect or is needing of changes. I am happy to amend the commit to meet project standards.

Thanks in advance.