### PR TITLE
Snippet for enabled click cast on non-cell frames

### DIFF
--- a/.snippets/ClickCastOnOtherFrames.lua
+++ b/.snippets/ClickCastOnOtherFrames.lua
@@ -26,6 +26,11 @@ local function UpdateClickCastings(noReload, onlyqueued)
         F:UpdateClickCastOnFrame(_G[name], snippet)
     end
 end
-Cell:UnregisterCallback("UpdateClickCastings",  "ThirdPartyClickCastings")
-Cell:RegisterCallback("UpdateClickCastings",  "ThirdPartyClickCastings", UpdateClickCastings)
+local function UpdateQueuedClickCastings()
+    UpdateClickCastings(true, true)
+end
+Cell:UnregisterCallback("UpdateClickCastings",  "UpdateClickCastings")
+Cell:UnregisterCallback("UpdateQueuedClickCastings",  "UpdateQueuedClickCastings")
+Cell:RegisterCallback("UpdateQueuedClickCastings", "UpdateQueuedClickCastings", UpdateQueuedClickCastings)
+Cell:RegisterCallback("UpdateClickCastings",  "UpdateClickCastings", UpdateClickCastings)
 

--- a/.snippets/ClickCastOnOtherFrames.lua
+++ b/.snippets/ClickCastOnOtherFrames.lua
@@ -1,4 +1,4 @@
-F = Cell.funcs
+local F = Cell.funcs
 
 local blizzardFrames = {
     "PlayerFrame",

--- a/.snippets/ClickCastOnOtherFrames.lua
+++ b/.snippets/ClickCastOnOtherFrames.lua
@@ -14,7 +14,6 @@ local blizzardFrames = {
     "PartyMemberFrame4PetFrame",
 }
 
-
 local function UpdateClickCastings(noReload, onlyqueued)
     F:UpdateClickCastings(noReload, onlyqueued)
     local snippet = F:GetBindingSnippet()
@@ -26,11 +25,13 @@ local function UpdateClickCastings(noReload, onlyqueued)
         F:UpdateClickCastOnFrame(_G[name], snippet)
     end
 end
+
 local function UpdateQueuedClickCastings()
     UpdateClickCastings(true, true)
 end
+
 Cell:UnregisterCallback("UpdateClickCastings",  "UpdateClickCastings")
 Cell:UnregisterCallback("UpdateQueuedClickCastings",  "UpdateQueuedClickCastings")
+
 Cell:RegisterCallback("UpdateQueuedClickCastings", "UpdateQueuedClickCastings", UpdateQueuedClickCastings)
 Cell:RegisterCallback("UpdateClickCastings",  "UpdateClickCastings", UpdateClickCastings)
-

--- a/.snippets/ClickCastOnOtherFrames.lua
+++ b/.snippets/ClickCastOnOtherFrames.lua
@@ -1,0 +1,39 @@
+F = Cell.funcs
+
+local blizzardFrames = {
+    "PlayerFrame",
+    "TargetFrame",
+    "PetFrame",
+    "PartyMemberFrame1",
+    "PartyMemberFrame2",
+    "PartyMemberFrame3",
+    "PartyMemberFrame4",
+    "PartyMemberFrame1PetFrame",
+    "PartyMemberFrame2PetFrame",
+    "PartyMemberFrame3PetFrame",
+    "PartyMemberFrame4PetFrame",
+}
+
+local function UpdateClickCastFrame(frame, snippet)
+    if frame then
+        F:ClearClickCastings(frame)
+        frame:SetAttribute("snippet", snippet)
+        F:SetBindingClicks(frame)
+        F:ApplyClickCastings(frame)
+    end
+end
+
+local function UpdateClickCastings(noReload, onlyqueued)
+    F:UpdateClickCastings(noReload, onlyqueued)
+    local snippet = F:GetBindingSnippet()
+    local ClickCastFrames = _G.ClickCastFrames or {}
+    for frame, _ in pairs(ClickCastFrames) do
+        UpdateClickCastFrame(frame, snippet)
+    end
+    for _, name in pairs(blizzardFrames) do
+        UpdateClickCastFrame(_G[name], snippet)
+    end
+end
+Cell:UnregisterCallback("UpdateClickCastings",  "ThirdPartyClickCastings")
+Cell:RegisterCallback("UpdateClickCastings",  "ThirdPartyClickCastings", UpdateClickCastings)
+

--- a/.snippets/ClickCastOnOtherFrames.lua
+++ b/.snippets/ClickCastOnOtherFrames.lua
@@ -14,24 +14,16 @@ local blizzardFrames = {
     "PartyMemberFrame4PetFrame",
 }
 
-local function UpdateClickCastFrame(frame, snippet)
-    if frame then
-        F:ClearClickCastings(frame)
-        frame:SetAttribute("snippet", snippet)
-        F:SetBindingClicks(frame)
-        F:ApplyClickCastings(frame)
-    end
-end
 
 local function UpdateClickCastings(noReload, onlyqueued)
     F:UpdateClickCastings(noReload, onlyqueued)
     local snippet = F:GetBindingSnippet()
     local ClickCastFrames = _G.ClickCastFrames or {}
     for frame, _ in pairs(ClickCastFrames) do
-        UpdateClickCastFrame(frame, snippet)
+        F:UpdateClickCastOnFrame(frame, snippet)
     end
     for _, name in pairs(blizzardFrames) do
-        UpdateClickCastFrame(_G[name], snippet)
+        F:UpdateClickCastOnFrame(_G[name], snippet)
     end
 end
 Cell:UnregisterCallback("UpdateClickCastings",  "ThirdPartyClickCastings")

--- a/Modules/ClickCastings.lua
+++ b/Modules/ClickCastings.lua
@@ -383,6 +383,9 @@ else
     end
 end
 
+function F:SetBindingClicks(b)
+    SetBindingClicks(b)
+end
 -- FIXME: hope BLZ fix this bug
 local function GetMouseWheelBindKey(fullKey, noTypePrefix)
     local modifier, key = strmatch(fullKey, "^(.*)type%-(.+)$")
@@ -395,7 +398,7 @@ local function GetMouseWheelBindKey(fullKey, noTypePrefix)
     end
 end
 
-local function GetBindingSnippet()
+function F:GetBindingSnippet()
     local bindingClicks = {}
     for _, t in pairs(clickCastingTable) do
         if t[1] ~= "notBound" then
@@ -440,7 +443,7 @@ end
 -- update click-castings
 -------------------------------------------------
 local previousClickCastings
-local function ClearClickCastings(b)
+function F:ClearClickCastings(b)
     if not previousClickCastings then return end
     b:SetAttribute("cell", nil)
     b:SetAttribute("menu", nil)
@@ -482,7 +485,7 @@ local function UpdatePlaceholder(b, attr)
     end
 end
 
-local function ApplyClickCastings(b)
+function F:ApplyClickCastings(b)
     for i, t in pairs(clickCastingTable) do
         local bindKey = t[1]
         if strfind(bindKey, "SCROLL") then
@@ -577,7 +580,7 @@ local function ApplyClickCastings(b)
     end
 end
 
-local function UpdateClickCastings(noReload, onlyqueued)
+function F:UpdateClickCastings(noReload, onlyqueued)
     F:Debug("|cff77ff77UpdateClickCastings:|r useCommon:", Cell.vars.clickCastings["useCommon"])
     clickCastingTable = Cell.vars.clickCastings["useCommon"] and Cell.vars.clickCastings["common"] or Cell.vars.clickCastings[Cell.vars.playerSpecID]
 
@@ -598,7 +601,7 @@ local function UpdateClickCastings(noReload, onlyqueued)
         end
     end
 
-    local snippet = GetBindingSnippet()
+    local snippet = F:GetBindingSnippet()
     F:Debug(snippet)
 
     -- REVIEW:
@@ -622,20 +625,20 @@ local function UpdateClickCastings(noReload, onlyqueued)
 
     F:IterateAllUnitButtons(function(b)
         -- clear if attribute already set
-        ClearClickCastings(b)
+        F:ClearClickCastings(b)
         -- update bindingClicks
         b:SetAttribute("snippet", snippet)
-        SetBindingClicks(b)
+        F:SetBindingClicks(b)
         -- load db and set attribute
-        ApplyClickCastings(b)
+        F:ApplyClickCastings(b)
     end, false, true)
 
     previousClickCastings = F:Copy(clickCastingTable)
 end
-Cell:RegisterCallback("UpdateClickCastings", "UpdateClickCastings", UpdateClickCastings)
+Cell:RegisterCallback("UpdateClickCastings", "UpdateClickCastings", F.UpdateClickCastings)
 
 local function UpdateQueuedClickCastings()
-    UpdateClickCastings(true, true)
+    F:UpdateClickCastings(true, true)
 end
 Cell:RegisterCallback("UpdateQueuedClickCastings", "UpdateQueuedClickCastings", UpdateQueuedClickCastings)
 

--- a/Modules/ClickCastings.lua
+++ b/Modules/ClickCastings.lua
@@ -586,7 +586,7 @@ function F:UpdateClickCastOnFrame(frame, snippet)
     ApplyClickCastings(b)
 end
 
-function UpdateClickCastings(noReload, onlyqueued)
+function F:UpdateClickCastings(noReload, onlyqueued)
     F:Debug("|cff77ff77UpdateClickCastings:|r useCommon:", Cell.vars.clickCastings["useCommon"])
     clickCastingTable = Cell.vars.clickCastings["useCommon"] and Cell.vars.clickCastings["common"] or Cell.vars.clickCastings[Cell.vars.playerSpecID]
 
@@ -635,7 +635,7 @@ function UpdateClickCastings(noReload, onlyqueued)
 
     previousClickCastings = F:Copy(clickCastingTable)
 end
-Cell:RegisterCallback("UpdateClickCastings", "UpdateClickCastings", UpdateClickCastings)
+Cell:RegisterCallback("UpdateClickCastings", "UpdateClickCastings", F.UpdateClickCastings)
 
 local function UpdateQueuedClickCastings()
     UpdateClickCastings(true, true)

--- a/Modules/ClickCastings.lua
+++ b/Modules/ClickCastings.lua
@@ -578,12 +578,14 @@ local function ApplyClickCastings(b)
 end
 
 function F:UpdateClickCastOnFrame(frame, snippet)
-    ClearClickCastings(frame)
-    -- update bindingClicks
-    frame:SetAttribute("snippet", snippet)
-    SetBindingClicks(frame)
-    -- load db and set attribute
-    ApplyClickCastings(frame)
+    if frame then
+        ClearClickCastings(frame)
+        -- update bindingClicks
+        frame:SetAttribute("snippet", snippet)
+        SetBindingClicks(frame)
+        -- load db and set attribute
+        ApplyClickCastings(frame)
+    end
 end
 
 function F:UpdateClickCastings(noReload, onlyqueued)

--- a/Modules/ClickCastings.lua
+++ b/Modules/ClickCastings.lua
@@ -578,12 +578,12 @@ local function ApplyClickCastings(b)
 end
 
 function F:UpdateClickCastOnFrame(frame, snippet)
-    ClearClickCastings(b)
+    ClearClickCastings(frame)
     -- update bindingClicks
-    b:SetAttribute("snippet", snippet)
-    SetBindingClicks(b)
+    frame:SetAttribute("snippet", snippet)
+    SetBindingClicks(frame)
     -- load db and set attribute
-    ApplyClickCastings(b)
+    ApplyClickCastings(frame)
 end
 
 function F:UpdateClickCastings(noReload, onlyqueued)

--- a/Modules/ClickCastings.lua
+++ b/Modules/ClickCastings.lua
@@ -383,9 +383,6 @@ else
     end
 end
 
-function F:SetBindingClicks(b)
-    SetBindingClicks(b)
-end
 -- FIXME: hope BLZ fix this bug
 local function GetMouseWheelBindKey(fullKey, noTypePrefix)
     local modifier, key = strmatch(fullKey, "^(.*)type%-(.+)$")
@@ -443,7 +440,7 @@ end
 -- update click-castings
 -------------------------------------------------
 local previousClickCastings
-function F:ClearClickCastings(b)
+function ClearClickCastings(b)
     if not previousClickCastings then return end
     b:SetAttribute("cell", nil)
     b:SetAttribute("menu", nil)
@@ -485,7 +482,7 @@ local function UpdatePlaceholder(b, attr)
     end
 end
 
-function F:ApplyClickCastings(b)
+function ApplyClickCastings(b)
     for i, t in pairs(clickCastingTable) do
         local bindKey = t[1]
         if strfind(bindKey, "SCROLL") then
@@ -580,7 +577,16 @@ function F:ApplyClickCastings(b)
     end
 end
 
-function F:UpdateClickCastings(noReload, onlyqueued)
+function F:UpdateClickCastOnFrame(frame, snippet)
+    ClearClickCastings(b)
+    -- update bindingClicks
+    b:SetAttribute("snippet", snippet)
+    SetBindingClicks(b)
+    -- load db and set attribute
+    ApplyClickCastings(b)
+end
+
+function UpdateClickCastings(noReload, onlyqueued)
     F:Debug("|cff77ff77UpdateClickCastings:|r useCommon:", Cell.vars.clickCastings["useCommon"])
     clickCastingTable = Cell.vars.clickCastings["useCommon"] and Cell.vars.clickCastings["common"] or Cell.vars.clickCastings[Cell.vars.playerSpecID]
 
@@ -624,21 +630,15 @@ function F:UpdateClickCastings(noReload, onlyqueued)
     -- end
 
     F:IterateAllUnitButtons(function(b)
-        -- clear if attribute already set
-        F:ClearClickCastings(b)
-        -- update bindingClicks
-        b:SetAttribute("snippet", snippet)
-        F:SetBindingClicks(b)
-        -- load db and set attribute
-        F:ApplyClickCastings(b)
+        F:UpdateClickCastOnFrame(b, snippet)
     end, false, true)
 
     previousClickCastings = F:Copy(clickCastingTable)
 end
-Cell:RegisterCallback("UpdateClickCastings", "UpdateClickCastings", F.UpdateClickCastings)
+Cell:RegisterCallback("UpdateClickCastings", "UpdateClickCastings", UpdateClickCastings)
 
 local function UpdateQueuedClickCastings()
-    F:UpdateClickCastings(true, true)
+    UpdateClickCastings(true, true)
 end
 Cell:RegisterCallback("UpdateQueuedClickCastings", "UpdateQueuedClickCastings", UpdateQueuedClickCastings)
 

--- a/Modules/ClickCastings.lua
+++ b/Modules/ClickCastings.lua
@@ -440,7 +440,7 @@ end
 -- update click-castings
 -------------------------------------------------
 local previousClickCastings
-function ClearClickCastings(b)
+local function ClearClickCastings(b)
     if not previousClickCastings then return end
     b:SetAttribute("cell", nil)
     b:SetAttribute("menu", nil)
@@ -482,7 +482,7 @@ local function UpdatePlaceholder(b, attr)
     end
 end
 
-function ApplyClickCastings(b)
+local function ApplyClickCastings(b)
     for i, t in pairs(clickCastingTable) do
         local bindKey = t[1]
         if strfind(bindKey, "SCROLL") then


### PR DESCRIPTION
I heard the feedback that this is a very much needed feature, so I tried to create a small snippet instead of trying to force the feature into the core.

I needed to export a new function for Updating click castings to make this proper and not a hack, otherwise the whole snippet is a copy paste of the ClickCastings.lua

Changes:
- F:UpdateClickCastOnFrame: This new function is what is called on all frames for updating click casts. (needed for the snippet)