### PR TITLE
Remove desaturation from vertical cooldown style animation

### DIFF
--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -158,9 +158,9 @@ local function Shared_CreateCooldown_Vertical(frame)
     local icon = cooldown:CreateTexture(nil, "ARTWORK")
     cooldown.icon = icon
     -- icon:SetTexCoord(0.12, 0.88, 0.12, 0.88)
-    icon:SetDesaturated(true)
+    -- icon:SetDesaturated(true)
     icon:SetAllPoints(frame.icon)
-    icon:SetVertexColor(0.5, 0.5, 0.5, 1)
+    icon:SetVertexColor(0.4, 0.4, 0.4, 1)
     icon:AddMaskTexture(mask)
 end
 


### PR DESCRIPTION
Considerations for the default behavior change:

- Closer parity with the "CLOCK" cooldown animation type (as well as default blizzard raid frames)
- Provides an additional visual dimension to assist in quickly determining which spells are expiring

Before:
![before](https://github.com/user-attachments/assets/a2768edf-48a5-42a9-9e9f-64b08c1e1fce)

After:
![after](https://github.com/user-attachments/assets/72b86404-fff8-4357-b30d-a23306a969dc)

