### PR TITLE
Selectable texture for shield bar indicator

### DIFF
--- a/Defaults/Layout_Defaults.lua
+++ b/Defaults/Layout_Defaults.lua
@@ -329,6 +329,7 @@ Cell.defaults.layout = {
             ["position"] = {"BOTTOMLEFT", nil, "BOTTOMLEFT", 0, 0},
             ["frameLevel"] = 5,
             ["height"] = 4,
+            ["texture"] = "Cell ".._G.DEFAULT,
             ["color"] = {1, 1, 0, 1},
             ["onlyShowOvershields"] = false,
         }, -- 16

--- a/Defaults/Layout_Defaults_Cata_Wrath.lua
+++ b/Defaults/Layout_Defaults_Cata_Wrath.lua
@@ -316,6 +316,7 @@ Cell.defaults.layout = {
             ["position"] = {"BOTTOMLEFT", nil, "BOTTOMLEFT", 0, 0},
             ["frameLevel"] = 5,
             ["height"] = 4,
+            ["texture"] = "Cell ".._G.DEFAULT,
             ["color"] = {1, 1, 0, 1},
             ["onlyShowOvershields"] = false,
         }, -- 16

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -11,6 +11,7 @@ local P = Cell.pixelPerfectFuncs
 
 local LCG = LibStub("LibCustomGlow-1.0")
 local LibTranslit = LibStub("LibTranslit-1.0")
+local LSM = LibStub("LibSharedMedia-3.0", true)
 
 local function noop() end
 
@@ -2096,7 +2097,16 @@ function I.CreateShieldBar(parent)
     shieldBar.parentHealthBar = parent.widgets.healthBar
 
     function shieldBar:SetColor(r, g, b, a)
-        tex:SetColorTexture(r, g, b, a)
+        tex:SetVertexColor(r, g, b, a)
+    end
+
+    function shieldBar:SetTexture(name, ...)
+        local barTextures = F.Copy(LSM:HashTable("statusbar"))
+        if barTextures[name] then
+            tex:SetTexture(barTextures[name], ...)
+        else
+            tex:SetTexture(name, ...)
+        end
     end
 
     function shieldBar:UpdatePixelPerfect()

--- a/Modules/Indicators/Indicators.lua
+++ b/Modules/Indicators/Indicators.lua
@@ -1566,7 +1566,7 @@ if Cell.isRetail or Cell.isMists then
         ["aggroBlink"] = {"enabled", "size", "position", "frameLevel"},
         ["aggroBorder"] = {"enabled", "thickness", "frameLevel"},
         ["aggroBar"] = {"enabled", "size", "position", "frameLevel"},
-        ["shieldBar"] = {"enabled", "checkbutton:onlyShowOvershields", "color-alpha", "height", "shieldBarPosition", "frameLevel"},
+        ["shieldBar"] = {"enabled", "checkbutton:onlyShowOvershields", "bartexture", "color-alpha", "height", "shieldBarPosition", "frameLevel"},
         ["aoeHealing"] = {"|cffb7b7b7"..L["Display a gradient texture when the unit receives a heal from your certain healing spells."], "enabled", "builtInAoEHealings", "customAoEHealings", "color", "height"},
         ["externalCooldowns"] = {L["Even if disabled, the settings below affect \"Externals + Defensives\" indicator"], "enabled", "builtInExternals", "customExternals", "durationVisibility", "checkbutton:showAnimation", "glowOptions", "size", "num:5", "orientation", "position", "frameLevel", "font1:stackFont", "font2:durationFont"},
         ["defensiveCooldowns"] = {L["Even if disabled, the settings below affect \"Externals + Defensives\" indicator"], "enabled", "builtInDefensives", "customDefensives", "durationVisibility", "checkbutton:showAnimation", "glowOptions", "size", "num:5", "orientation", "position", "frameLevel", "font1:stackFont", "font2:durationFont"},
@@ -1610,7 +1610,7 @@ elseif Cell.isCata or Cell.isWrath then
         ["aggroBlink"] = {"enabled", "size", "position", "frameLevel"},
         ["aggroBorder"] = {"enabled", "thickness", "frameLevel"},
         ["aggroBar"] = {"enabled", "size", "position", "frameLevel"},
-        ["shieldBar"] = {"enabled", "checkbutton:onlyShowOvershields", "color-alpha", "height", "shieldBarPosition", "frameLevel"},
+        ["shieldBar"] = {"enabled", "checkbutton:onlyShowOvershields", "bartexture", "color-alpha", "height", "shieldBarPosition", "frameLevel"},
         ["powerWordShield"] = {L["To show shield value, |cffff2727Glyph of Power Word: Shield|r is required"], "enabled", "checkbutton:shieldByMe", "shape", "size-square", "position", "frameLevel"},
         ["aoeHealing"] = {"|cffb7b7b7"..L["Display a gradient texture when the unit receives a heal from your certain healing spells."], "enabled", "builtInAoEHealings", "customAoEHealings", "color", "height"},
         ["externalCooldowns"] = {L["Even if disabled, the settings below affect \"Externals + Defensives\" indicator"], "enabled", "builtInExternals", "customExternals", "durationVisibility", "checkbutton:showAnimation", "glowOptions", "size", "num:5", "orientation", "position", "frameLevel", "font1:stackFont", "font2:durationFont"},
@@ -1753,6 +1753,7 @@ local function ShowIndicatorSettings(id)
         if currentSetting == "barOrientation" then currentSetting = "orientation" end
         if currentSetting == "durationVisibility" then currentSetting = "showDuration" end
         if currentSetting == "powerFormat" then currentSetting = "format" end
+        if currentSetting == "bartexture" then currentSetting = "texture" end
 
         -- enabled
         if currentSetting == "enabled" then

--- a/Widgets/Widgets_IndicatorSettings.lua
+++ b/Widgets/Widgets_IndicatorSettings.lua
@@ -7,6 +7,7 @@ local I = Cell.iFuncs
 ---@type PixelPerfectFuncs
 local P = Cell.pixelPerfectFuncs
 local LCG = LibStub("LibCustomGlow-1.0")
+local LSM = LibStub("LibSharedMedia-3.0", true)
 
 -----------------------------------------
 -- Color
@@ -4088,6 +4089,63 @@ local function CreateSetting_Texture(parent)
     return widget
 end
 
+local function CreateSetting_BarTexture(parent)
+    local widget
+
+    if not settingWidgets["bartexture"] then
+        widget = Cell.CreateFrame("CellIndicatorSettings_BarTexture", parent, 240, 50)
+        settingWidgets["bartexture"] = widget
+
+        widget.textureDropdown = Cell.CreateDropdown(widget, 245, "texture")
+        widget.textureDropdown:SetPoint("TOPLEFT", 5, -20)
+
+        local items = {}
+        local textures, textureNames
+        local defaultTexture, defaultTextureName = "Interface\\AddOns\\Cell\\Media\\statusbar.tga", "Cell ".._G.DEFAULT
+
+        textures, textureNames = F.Copy(LSM:HashTable("statusbar")), F.Copy(LSM:List("statusbar"))
+
+        -- make default texture first
+        F.TRemove(textureNames, defaultTextureName)
+        tinsert(textureNames, 1, defaultTextureName)
+
+        for _, name in pairs(textureNames) do
+            tinsert(items, {
+                ["text"] = name,
+                ["texture"] = textures[name],
+                ["onClick"] = function()
+                    widget.func(name)
+                end,
+            })
+        end
+
+        widget.textureDropdown:SetItems(items)
+
+        widget.durationVisibilityText = widget:CreateFontString(nil, "OVERLAY", font_name)
+        widget.durationVisibilityText:SetText(L["Texture"])
+        widget.durationVisibilityText:SetPoint("BOTTOMLEFT", widget.textureDropdown, "TOPLEFT", 0, 1)
+
+        -- callback
+        function widget:SetFunc(func)
+            widget.func = func
+        end
+
+        -- show db value
+        function widget:SetDBValue(value)
+            if textures[value] then
+                widget.textureDropdown:SetSelected(value, textures[value])
+            else
+                widget.textureDropdown:SetSelected(defaultTextureName, defaultTexture)
+            end
+        end
+    else
+        widget = settingWidgets["bartexture"]
+    end
+
+    widget:Show()
+    return widget
+end
+
 local function CreateAuraButtons(parent, auraButtons, auraTable, noUpDownButtons, isZeroValid, hasColorPicker, updateHeightFunc)
     local n = #auraTable
 
@@ -6781,6 +6839,7 @@ local builders = {
     ["targetedSpellsGlow"] = CreateSetting_Glow,
     ["texture"] = CreateSetting_Texture,
     ["builtInAoEHealings"] = CreateSetting_BuiltIns,
+    ["bartexture"] = CreateSetting_BarTexture,
     ["builtInDefensives"] = CreateSetting_BuiltIns,
     ["builtInExternals"] = CreateSetting_BuiltIns,
     ["builtInCrowdControls"] = CreateSetting_BuiltIns,


### PR DESCRIPTION
Adds a texture to the Shield Bar indicator and a UI widget to set it, allowing it to match the bar when used as an overlay.

![Screenshot_20241011_171709](https://github.com/user-attachments/assets/7334063b-1204-4e84-94fe-923aeb2f7da1)
