### PR TITLE
Updating GetMouseFocus for Classic (Era and Cata)

### DIFF
--- a/Utils.lua
+++ b/Utils.lua
@@ -1728,11 +1728,7 @@ end
 -- frame
 -------------------------------------------------
 function F:GetMouseFocus()
-    if Cell.isRetail then
-        return GetMouseFoci()[1]   -- Latest Beta build changed this to return the table under key `1`
-    else
-        return GetMouseFocus()
-    end
+  return GetMouseFoci()[1]   -- Latest Beta build changed this to return the table under key `1`
 end
 
 -------------------------------------------------

--- a/Utils.lua
+++ b/Utils.lua
@@ -1728,7 +1728,11 @@ end
 -- frame
 -------------------------------------------------
 function F:GetMouseFocus()
-  return GetMouseFoci()[1]   -- Latest Beta build changed this to return the table under key `1`
+    if GetMouseFoci then
+        return GetMouseFoci()[1]
+    else
+        return GetMouseFocus()
+    end
 end
 
 -------------------------------------------------


### PR DESCRIPTION
After the latest big update the API for classic updated to match the retail API for `GetMouseFocus`. I noticed in game this breaks the use of spotlight frames, you cannot change who to spotlight with the click + drag feature