### PR TITLE
[feature] Support down ranking of spells in Classic

### DIFF
--- a/Modules/ClickCastings/ClickCastings.lua
+++ b/Modules/ClickCastings/ClickCastings.lua
@@ -529,6 +529,13 @@ local function ApplyClickCastings(b)
                 spellName = spellName .. "(" .. (subtext or EXPANSION_NAME8) .. ")"
             end
 
+            if Cell.isVanilla then
+                local subtext = C_Spell.GetSpellSubtext(t[3]) -- Get spell rank
+                if subtext then
+                    spellName = spellName .. "(" .. subtext .. ")"
+                end
+            end
+
             local condition = ""
             if not F:IsSoulstone(spellName) then
                 condition = F:IsResurrectionForDead(spellName) and ",dead" or ",nodead"

--- a/Modules/ClickCastings/ClickCastings.lua
+++ b/Modules/ClickCastings/ClickCastings.lua
@@ -531,7 +531,7 @@ local function ApplyClickCastings(b)
 
             if Cell.isVanilla then
                 local subtext = C_Spell.GetSpellSubtext(t[3]) -- Get spell rank
-                if subtext then
+                if subtext and subtext ~= "" then
                     spellName = spellName .. "(" .. subtext .. ")"
                 end
             end


### PR DESCRIPTION
This is related to #177 (maybe fixes it entirely).

It allows users to add specific spell IDs and Cell will respect the rank related to that spell.

The default list of spells is not changed, so users still have to enter the correct spell ID to actually use a lower rank.