### PR TITLE
Add maxValue settings to custom Bar indicator

### DIFF
--- a/Defaults/Indicator_Defaults.lua
+++ b/Defaults/Indicator_Defaults.lua
@@ -68,7 +68,7 @@ function I.GetDefaultCustomIndicatorTable(name, indicatorName, type, auraType)
             },
             ["showStack"] = false,
             ["showDuration"] = false,
-            ["maxValue"] = {0, true},
+            ["maxValue"] = {false, 10, true},
             ["auraType"] = auraType,
             ["auras"] = {},
             ["glowOptions"] = {"None", {0.95, 0.95, 0.32, 1}}
@@ -92,7 +92,7 @@ function I.GetDefaultCustomIndicatorTable(name, indicatorName, type, auraType)
             },
             ["showStack"] = false,
             ["showDuration"] = false,
-            ["maxValue"] = {0, true},
+            ["maxValue"] = {false, 10, true},
             ["auraType"] = auraType,
             ["auras"] = {},
             ["glowOptions"] = {"None", {0.95, 0.95, 0.32, 1}}

--- a/Defaults/Indicator_Defaults.lua
+++ b/Defaults/Indicator_Defaults.lua
@@ -67,6 +67,7 @@ function I.GetDefaultCustomIndicatorTable(name, indicatorName, type, auraType)
             },
             ["showStack"] = false,
             ["showDuration"] = false,
+            ["maxValue"] = {0, true},
             ["auraType"] = auraType,
             ["auras"] = {},
         }

--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -1325,12 +1325,12 @@ local function Bar_SetCooldown(bar, start, duration, debuffType, texture, count)
 end
 
 local function Bar_SetMaxValue(bar, maxValue)
-    if maxValue[1] == 0 then
+    if maxValue[1]then
+        bar.maxValue = maxValue[2]
+        bar.allowSmaller = maxValue[3]
+    else
         bar.maxValue = nil
         bar.allowSmaller = nil
-    else
-        bar.maxValue = maxValue[1]
-        bar.allowSmaller = maxValue[2]
     end
 end
 
@@ -1353,6 +1353,8 @@ function I.CreateAura_Bar(name, parent)
     bar.SetCooldown = Bar_SetCooldown
     bar.ShowStack = Shared_ShowStack
     bar.ShowDuration = Shared_ShowDuration
+    bar.SetMaxValue = Bar_SetMaxValue
+    bar.SetupGlow = Shared_SetupGlow
     bar.SetColors = Bar_SetColors
 
     return bar
@@ -1412,8 +1414,8 @@ local function Bars_SetCooldown(bar, start, duration, debuffType, texture, count
             bar.duration:Show()
         end
 
-        if bar.parent.maxValue then
-            bar:SetMinMaxValues(0, bar.parent.allowSmaller and min(bar.parent.maxValue, duration) or bar.parent.maxValue)
+        if bar.maxValue then
+            bar:SetMinMaxValues(0, bar.allowSmaller and min(bar.maxValue, duration) or bar.maxValue)
         else
             bar:SetMinMaxValues(0, duration)
         end
@@ -1429,12 +1431,8 @@ local function Bars_SetCooldown(bar, start, duration, debuffType, texture, count
 end
 
 local function Bars_SetMaxValue(bars, maxValue)
-    if maxValue[1] == 0 then
-        bars.maxValue = nil
-        bars.allowSmaller = nil
-    else
-        bars.maxValue = maxValue[1]
-        bars.allowSmaller = maxValue[2]
+    for _, bar in ipairs(bars) do
+        bar:SetMaxValue(maxValue)
     end
 end
 

--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -1214,7 +1214,11 @@ local function Bar_SetCooldown(bar, start, duration, debuffType, texture, count)
             bar.duration:Show()
         end
 
-        bar:SetMinMaxValues(0, duration)
+        if bar.maxValue then
+            bar:SetMinMaxValues(0, bar.allowSmaller and min(bar.maxValue, duration) or bar.maxValue)
+        else
+            bar:SetMinMaxValues(0, duration)
+        end
         bar._start = start
         bar._duration = duration
         bar._elapsed = 0.1 -- update immediately
@@ -1223,6 +1227,16 @@ local function Bar_SetCooldown(bar, start, duration, debuffType, texture, count)
 
     bar.stack:SetText((count == 0 or count == 1) and "" or count)
     bar:Show()
+end
+
+local function Bar_SetMaxValue(bar, maxValue)
+    if maxValue[1] == 0 then
+        bar.maxValue = nil
+        bar.allowSmaller = nil
+    else
+        bar.maxValue = maxValue[1]
+        bar.allowSmaller = maxValue[2]
+    end
 end
 
 local function Bar_SetColors(bar, colors)
@@ -1244,6 +1258,7 @@ function I.CreateAura_Bar(name, parent)
     bar.SetCooldown = Bar_SetCooldown
     bar.ShowStack = Shared_ShowStack
     bar.ShowDuration = Shared_ShowDuration
+    bar.SetMaxValue = Bar_SetMaxValue
     bar.SetColors = Bar_SetColors
 
     return bar

--- a/Modules/Indicators/Indicators.lua
+++ b/Modules/Indicators/Indicators.lua
@@ -1697,7 +1697,7 @@ local function ShowIndicatorSettings(id)
         elseif indicatorType == "text" then
             settingsTable = {"enabled", "auras", "duration", "stack", "colors", "position", "frameLevel", "font-noOffset"}
         elseif indicatorType == "bar" then
-            settingsTable = {"enabled", "auras", "colors", "checkbutton3:showStack", "durationVisibility", "barOrientation", "size", "position", "frameLevel", "font1:stackFont", "font2:durationFont"}
+            settingsTable = {"enabled", "auras", "maxValue", "colors", "checkbutton3:showStack", "durationVisibility", "barOrientation", "size", "position", "frameLevel", "font1:stackFont", "font2:durationFont"}
         elseif indicatorType == "bars" then
             settingsTable = {"enabled", "auras", "maxValue", "checkbutton3:showStack", "durationVisibility", "size", "num:10", "numPerLine:10", "spacing", "orientation", "position", "frameLevel", "font1:stackFont", "font2:durationFont"}
         elseif indicatorType == "rect" then
@@ -1961,6 +1961,14 @@ local function ShowIndicatorSettings(id)
                 indicatorTable["size"][2] = value[2]
                 indicatorTable["border"] = value[3]
                 Cell.Fire("UpdateIndicators", notifiedLayout, indicatorName, currentSetting, value)
+            end)
+        
+        -- maxValue
+        elseif currentSetting == "maxValue" then
+            w:SetDBValue(indicatorTable["maxValue"])
+            w:SetFunc(function(value)
+                indicatorTable["maxValue"] = value
+                Cell.Fire("UpdateIndicators", notifiedLayout, indicatorName, "maxValue", value)
             end)
 
         -- colors

--- a/Modules/Indicators/Indicators.lua
+++ b/Modules/Indicators/Indicators.lua
@@ -1965,14 +1965,6 @@ local function ShowIndicatorSettings(id)
                 Cell.Fire("UpdateIndicators", notifiedLayout, indicatorName, currentSetting, value)
             end)
 
-        -- maxValue
-        elseif currentSetting == "maxValue" then
-            w:SetDBValue(indicatorTable["maxValue"])
-            w:SetFunc(function(value)
-                indicatorTable["maxValue"] = value
-                Cell.Fire("UpdateIndicators", notifiedLayout, indicatorName, "maxValue", value)
-            end)
-
         -- colors
         elseif currentSetting == "colors" then
             w:SetDBValue(indicatorTable["colors"], indicatorTable["auraType"])

--- a/Revise.lua
+++ b/Revise.lua
@@ -3273,6 +3273,12 @@ function F.Revise()
                         i.glowOptions = {"None", {0.95, 0.95, 0.32, 1}}
                     end
                 end
+
+                if i.type == "bar" or i.type == "bars" then
+                    if type(i.maxValue) ~= "table" or #i.maxValue ~= 3 then
+                        i.maxValue = {false, 10, true}
+                    end
+                end
             end
         end
 

--- a/Widgets/Widgets_IndicatorSettings.lua
+++ b/Widgets/Widgets_IndicatorSettings.lua
@@ -6412,40 +6412,25 @@ local function CreateSetting_MaxValue(parent)
     local widget
 
     if not settingWidgets["maxValue"] then
-        widget = Cell.CreateFrame("CellIndicatorSettings_MaxValue", parent, 240, 70)
+        widget = Cell.CreateFrame("CellIndicatorSettings_MaxValue", parent, 240, 80)
         settingWidgets["maxValue"] = widget
 
-        widget.maxValue = Cell.CreateDropdown(widget, 245)
-        widget.maxValue:SetPoint("TOPLEFT", 5, -20)
-        local items = {
-            {
-                ["text"] = L["Disabled"],
-                ["value"] = 0,
-                ["onClick"] = function()
-                    widget.allowSmaller:SetEnabled(false)
-                    widget.func({0, widget.allowSmaller:GetChecked()})
-                end,
-            }
-        }
-        local values = {5, 10, 15, 20, 25, 30}
-        for _, v in pairs(values) do
-            tinsert(items, {
-                ["text"] = v .. " " .. L["sec"],
-                ["value"] = v,
-                ["onClick"] = function()
-                    widget.allowSmaller:SetEnabled(true)
-                    widget.func({v, widget.allowSmaller:GetChecked()})
-                end,
-            })
-        end
-        widget.maxValue:SetItems(items)
+        widget.cb = Cell.CreateCheckButton(widget, L["Set Bar Max Value"], function(checked)
+            widget.maxValue:SetEnabled(checked)
+            widget.allowSmaller:SetEnabled(checked)
+            widget.func({checked, tonumber(widget.maxValue:GetText()) or 0, widget.allowSmaller:GetChecked()})
+        end)
+        widget.cb:SetPoint("TOPLEFT", 5, -8)
 
-        widget.maxValueText = widget:CreateFontString(nil, "OVERLAY", font_name)
-        widget.maxValueText:SetText(L["Set Bar Max Value"])
-        widget.maxValueText:SetPoint("BOTTOMLEFT", widget.maxValue, "TOPLEFT", 0, 1)
+        widget.maxValue = Cell.CreateEditBox(widget, 50, 20, nil, nil, true)
+        widget.maxValue:SetPoint("TOPLEFT", widget.cb, "BOTTOMLEFT", 0, -8)
+        widget.maxValue:SetMaxLetters(5)
+        widget.maxValue:AddConfirmButton(function()
+            widget.func({widget.cb:GetChecked(), tonumber(widget.maxValue:GetText()) or 0, widget.allowSmaller:GetChecked()})
+        end, "number")
 
         widget.allowSmaller = Cell.CreateCheckButton(widget, L["Allow smaller value"], function(checked)
-            widget.func({widget.maxValue:GetSelected(), checked})
+            widget.func({widget.cb:GetChecked(), tonumber(widget.maxValue:GetText()) or 0, checked})
         end)
         widget.allowSmaller:SetPoint("TOPLEFT", widget.maxValue, "BOTTOMLEFT", 0, -8)
 
@@ -6456,9 +6441,11 @@ local function CreateSetting_MaxValue(parent)
 
         -- show db value
         function widget:SetDBValue(maxValue)
-            widget.maxValue:SetSelectedValue(maxValue[1])
-            widget.allowSmaller:SetChecked(maxValue[2])
-            widget.allowSmaller:SetEnabled(maxValue[1] ~= 0)
+            widget.cb:SetChecked(maxValue[1])
+            widget.maxValue:SetText(maxValue[2])
+            widget.maxValue:SetEnabled(maxValue[1])
+            widget.allowSmaller:SetChecked(maxValue[3])
+            widget.allowSmaller:SetEnabled(maxValue[1])
         end
     else
         widget = settingWidgets["maxValue"]


### PR DESCRIPTION
This the workaround I was speaking about in https://github.com/enderneko/Cell/issues/336.
I found out that Bars already had the feature I need. I simply made it available for Bar too.

I tested in game, it works as expected.

One improvement I may look for is to be able to freely input the `maxValue` instead of choosing among `Disabled, 5, 10, 15, 20, 25, 30`. But if I do, it will be in a future PR.