### PR TITLE
Switch to partial aura updates

### DIFF
--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1575,7 +1575,7 @@ local function UpdateMirrorImage(b, event)
         b._mirror_image = nil
     end
     if b._indicatorsReady then
-        UnitButton_UpdateBuffs(b, true) -- UNIT_AURA is staggered, maybe force full update here, not sure if needed
+        UnitButton_UpdateBuffs(b, false) -- should be no full update needed, indicator update is done
     end
 end
 
@@ -1605,7 +1605,7 @@ local function UpdateMassBarrier(b, event)
         b._mass_barrier_icon = nil
     end
     if b._indicatorsReady then
-        UnitButton_UpdateBuffs(b, true) -- UNIT_AURA is staggered, maybe force full update here, not sure if needed
+        UnitButton_UpdateBuffs(b, false) -- should be no full update needed, indicator update is done
     end
 end
 


### PR DESCRIPTION
This switches the aura handling to partial updates instead of running full updates with each UNIT_AURA event.
Full updates are done where needed, partial aura updates are performed otherwise.

This should greatly improve performance in larger raid groups as it reduces the amount of aura updates through API calls.
Indicator handling is still done, though, for each aura, as the indicators are wiped with each update still.