### PR TITLE
fixes for Anniversary Dual Specc

### DIFF
--- a/Core_Vanilla.lua
+++ b/Core_Vanilla.lua
@@ -736,7 +736,6 @@ end
 
 
 function eventFrame:PLAYER_TALENT_UPDATE()
-
     F.UpdateClickCastingProfileLabel()
 end
 

--- a/Core_Vanilla.lua
+++ b/Core_Vanilla.lua
@@ -130,6 +130,7 @@ local function PreUpdateLayout()
     end
 end
 Cell.RegisterCallback("GroupTypeChanged", "Core_GroupTypeChanged", PreUpdateLayout)
+Cell.RegisterCallback("ActiveTalentGroupChanged", "Core_ActiveTalentGroupChanged", PreUpdateLayout)
 
 -------------------------------------------------
 -- events
@@ -643,10 +644,12 @@ function eventFrame:PLAYER_LOGIN()
     F.Debug("|cffbbbbbb=== PLAYER_LOGIN ===")
     eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
     eventFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
-    eventFrame:RegisterEvent("UI_SCALE_CHANGED")
     if GetNumTalentGroups() == 2 then -- check if dualspec is active, if yes register talent swap event
         eventFrame:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
+        eventFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
     end
+    eventFrame:RegisterEvent("UI_SCALE_CHANGED")
+
 
     Cell.vars.playerNameShort = GetUnitName("player")
     Cell.vars.playerNameFull = F.UnitFullName("player")
@@ -732,6 +735,10 @@ function eventFrame:ACTIVE_TALENT_GROUP_CHANGED()
 end
 
 
+function eventFrame:PLAYER_TALENT_UPDATE()
+
+    F.UpdateClickCastingProfileLabel()
+end
 
 eventFrame:SetScript("OnEvent", function(self, event, ...)
     self[event](self, ...)


### PR DESCRIPTION
After testing the beta release tonight in Naxxramas I've found the changes for Anniversary not working as inteded. Primarly 

`Cell.RegisterCallback("ActiveTalentGroupChanged", "Core_ActiveTalentGroupChanged", PreUpdateLayout)`

was missing from the Core_Vanilla.lua which caused the layouts not to switch properly. I vaguely remember using it when testing the changes the first time around, though I am unsure why it didn't make it into the initiall pull request. :(

I've also added   ` F.UpdateClickCastingProfileLabel()` mirroring Core_Wrath.lua
