### PR TITLE
fix duration numbers not showing in retail patch 11.2.7.64743

### DIFF
--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -383,7 +383,7 @@ local function Icon_OnUpdate_ElapsedTime(frame, elapsed)
     frame._remain = frame._duration - (GetTime() - frame._start)
     if frame._remain < 0 then frame._remain = 0 end
 
-    if frame._remain > frame._threshold then
+   if not frame._threshold or frame._remain > frame._threshold then
         frame.duration:SetText("")
         return
     end


### PR DESCRIPTION
`277x Cell/Indicators/Base.lua:373: attempt to compare number with nil [Cell/Indicators/Base.lua]:373: in function <Cell/Indicators/Base.lua:340> Locals: frame = CellIndicatorsPreviewButtonExternalCooldown2 { BottomLeftCorner = Texture { } showDuration = false duration = FontString { } showAnimation = true TopLeftCorner = Texture { } RightEdge = Texture { } ag = AnimationGroup { } _remain = 4.445000 _start = 429680.802000 _elapsed = 0.056000 stack = FontString { } _duration = 13 _threshold = 13 glowType = "None" PixelSnapDisabled = true glowOptions = <table> { } points = <table> { } preview = Frame { } TopRightCorner = Texture { } cooldown = StatusBar { } style = "VERTICAL" TopEdge = Texture { } backdropInfo = <table> { } icon = CellIndicatorsPreviewButtonExternalCooldown2Icon { } Center = Texture { } BottomEdge = Texture { } LeftEdge = Texture { } BottomRightCorner = Texture { } } elapsed = 0.004000 (*temporary) = 4.445000 (*temporary) = nil (*temporary) = 429680.802000 (*temporary) = nil (*temporary) = nil (*temporary) = "attempt to compare number with nil" Cell = <table> { MIN_VERSION = 246 isMists = false MIN_QUICKASSIST_VERSION = 246 flavor = "retail" funcs = <table> { } snippetVars = <table> { } MIN_CLICKCASTINGS_VERSION = 246 IndentationLib = <table> { } isRetail = true animations = <table> { } frames = <table> { } MIN_INDICATORS_VERSION = 246 unitButtons = <table> { } versionNum = 270 bFuncs = <table> { } vars = <table> { } loaded = true hasHighestPriority = false version = "r270-release" pixelPerfectFuncs = <table> { } isVanilla = false wowSupporters = <table> { } isTWW = true menu = CellCascadingMenu { } supporters1 = <table> { } MIN_LAYOUTS_VERSION = 246 MIN_DEBUFFS_VERSION = 246 supporters2 = <table> { } L = <table> { } uFuncs = <table> { } defaults = <table> { } iFuncs = <table> { } isWrath = false isCata = false }`

Fix for this error, not sure if correct.