### PR TITLE
WoW 12.0.0 (Midnight) Compatibility — Secret Values, CLEU Removal, and Spell Updates (r275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# r275.5 Added Midnight Raid Debuffs
+
+## Raid Debuffs
+- Added initial Midnight expansion raid debuffs for all 12 instances (6 raids, 6 dungeons) and 41 bosses.
+- Boss ability spell IDs sourced from the Encounter Journal via wago.tools DB2 tables.
+- General (trash mob) debuffs still need to be collected in-game and added in a future update.
+- Spells may need further in-game curation to filter out non-debuff abilities.
+
 # r275-release — WoW 12.0.0 (Midnight) Compatibility
 
 Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing the removal of `COMBAT_LOG_EVENT_UNFILTERED`, the introduction of Secret Values, blocked addon communications during restricted contexts, and spell/API removals. Interface bumped to 120001.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,59 @@
+# r275-release — WoW 12.0.0 (Midnight) Compatibility
+
+Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing the removal of `COMBAT_LOG_EVENT_UNFILTERED`, the introduction of Secret Values, blocked addon communications during restricted contexts, and spell/API removals. Interface bumped to 120001.
+
+## Secret Values (12.0.0+)
+- Add `Cell.isMidnight` detection flag and `F.IsSecretValue()`, `F.IsAuraRestricted()`, `F.IsCooldownRestricted()` utility functions
+- Add per-aura `F.IsAuraNonSecret()`, `F.IsSpellAuraNonSecret()`, `F.IsValueNonSecret()` helpers — non-secret (whitelisted) auras now get real countdown timers, source detection, and duration display; secret auras gracefully degrade
+- UnitButton: major dual-path refactor — Midnight uses `UnitHealPredictionCalculator`, `C_CurveUtil.CreateCurve()`, and StatusBar overlays for health/prediction/shields; pre-Midnight retains arithmetic-based paths
+- Appearance: IncomingHeal widget uses `SetStatusBarTexture` on Midnight (StatusBar) vs `SetTexture` pre-Midnight (Texture)
+- Indicator_Defaults: local `DebuffTypeColor` fallback for when the WoW global is removed
+- Per-field `F.IsValueNonSecret()` guards before every arithmetic operation on temporal aura fields (`expirationTime`, `duration`, `applications`, and cached `old*` variants)
+
+## CLEU Removal
+- AoEHealing: disabled on Midnight (CLEU unavailable); frame still exists for potential future non-CLEU API
+- StatusIcon: soulstone/resurrection tracking switches to `UNIT_AURA` + `UNIT_HEALTH` on Midnight
+- NPCFrame: boss6-8 health/aura tracking switches to unit events on Midnight
+- DeathReport: full refactor — Midnight uses `UNIT_HEALTH` + `UnitIsDeadOrGhost()` for death detection
+- UnitButton: removed `CombatLogGetCurrentEventInfo` dependency and `CheckCLEURequired`
+- General: removed `useCleuHealthUpdater` checkbox (CLEU health updater obsolete)
+- Revise: r275 migration removes `useCleuHealthUpdater` from saved variables
+
+## Comm Restrictions
+- Comm: `IsCommRestricted()` detects encounters/M+/PvP; all `SendCommMessage` calls guarded; pending queue with flush on `ENCOUNTER_END`
+- Nicknames: all nickname sync sends guarded with `F.IsCommRestricted()`
+
+## Heal Prediction & Health Bar Fixes
+- Created a dedicated `healPredictionCalculator` separate from the shared `healthCalculator` — the heal prediction function's `SetIncomingHealClampMode(0)` and `SetIncomingHealOverflowPercent(1.0)` were persisting on the shared calculator and corrupting health/absorb reads
+- Incoming heal bar is now a StatusBar (instead of Texture) anchored to the health fill texture edge
+- Fixed health bar loss color stuck on white/full-health — `self.states.healthPercent` was never set on the Midnight path; now populated from `calculator:GetCurrentHealthPercent()` with a secret-safe fallback
+- Dispels now show correctly because `HandleDebuff` completes to the dispel detection code (string/boolean fields, not temporal arithmetic)
+
+## Spell & Default Updates
+- Removed: Engulf, Renew, Power Word: Life, Void Shift, Shadow Covenant, Divine Star, Cloudburst Totem, Minor Cenarion Ward, Premonition of Solace
+- Added: Plea (200829, Disc Priest)
+- Added missing healing spells to default indicator list (Evoker, Monk, Paladin, Priest)
+- Moved: Prayer of Mending from class-wide to Holy spec only
+- Fixed: Shaman Poison dispel node IDs (103609 → 103599)
+
+## Defensive Nil Guards & Fixes
+- MainFrame: nil guards for `currentLayoutTable` and `tooltipPoint`
+- HideBlizzard: guards for `PartyMemberFramePool`, `CompactPartyFrame`, `PartyMemberBackground`
+- RaidDebuffs: nil guard for encounter journal expansion data
+- TargetedSpells: skip enemy spell tracking during restricted periods
+- BuffTracker: guard `GetAuraDataBySpellName` when auras are restricted; per-aura `sourceUnit` check
+- QuickCast: skip only secret auras in `ForEachAura`
+- Custom indicators: per-aura secret check for duration/start
+- Appearance: ticker nil guard in preview `OnHide`
+
+## Infrastructure
+- All 22 XML files updated from `FrameXML/UI_shared.xsd` → `Blizzard_SharedXML/UI.xsd`
+- Core: version constants bumped to 275, `GetBattlegroundInfo` guard added
+
+---
+
+# r274-release
+
 [View Full Changelog](https://github.com/enderneko/Cell/compare/r273-release...c376c32494926a90b93cc63bfc564234fb6e5cd6)
 
 - Update Molten Core debuffs

--- a/Cell.toc
+++ b/Cell.toc
@@ -1,6 +1,6 @@
-## Interface: 110207
+## Interface: 120001
 ## Title: Cell
-## Version: r274-release
+## Version: r275-release
 ## Author: enderneko
 ## X-Flavor: Mainline
 ## SavedVariables: CellDB, CellDBBackup

--- a/Comm/Comm.lua
+++ b/Comm/Comm.lua
@@ -29,6 +29,50 @@ local function Deserialize(encoded)
 end
 
 -----------------------------------------
+-- Comm restriction (Midnight 12.0.0+)
+-- Addon communications are blocked during active encounters, M+ keys, and PvP matches.
+-----------------------------------------
+local function IsCommRestricted()
+    if not Cell.isMidnight then return false end
+    -- Check encounter
+    if IsEncounterInProgress and IsEncounterInProgress() then return true end
+    -- Check M+
+    if C_MythicPlus and C_MythicPlus.IsRunActive and C_MythicPlus.IsRunActive() then return true end
+    -- Check PvP
+    if C_PvP and C_PvP.IsActiveBattlefield and C_PvP.IsActiveBattlefield() then return true end
+    return false
+end
+
+-- Export for use in other Comm files (e.g. Nicknames.lua)
+function F.IsCommRestricted()
+    return IsCommRestricted()
+end
+
+-- Simple queue for deferred sends (used when comms are restricted)
+local pendingComms = {}
+
+local function QueueComm(prefix, message, channel, target, priority)
+    tinsert(pendingComms, {prefix=prefix, message=message, channel=channel, target=target, priority=priority})
+end
+
+local function FlushPendingComms()
+    if IsCommRestricted() then return end
+    if #pendingComms == 0 then return end
+    local toSend = pendingComms
+    pendingComms = {}
+    for _, msg in ipairs(toSend) do
+        Comm:SendCommMessage(msg.prefix, msg.message, msg.channel, msg.target, msg.priority or "NORMAL")
+    end
+end
+
+local commFrame = CreateFrame("Frame")
+commFrame:RegisterEvent("ENCOUNTER_END")
+commFrame:RegisterEvent("PLAYER_LEAVING_WORLD")
+commFrame:SetScript("OnEvent", function()
+    C_Timer.After(1, FlushPendingComms)
+end)
+
+-----------------------------------------
 -- for WA
 -----------------------------------------
 function F.Notify(type, ...)
@@ -64,6 +108,11 @@ function eventFrame:GROUP_ROSTER_UPDATE()
     if IsInGroup() then
         eventFrame:UnregisterEvent("GROUP_ROSTER_UPDATE")
         UpdateSendChannel()
+        -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+        if IsCommRestricted() then
+            F.Debug("Cell: Comm suppressed - restricted context (CELL_VERSION group)")
+            return
+        end
         Comm:SendCommMessage("CELL_VERSION", Cell.version, sendChannel, nil, "NORMAL")
     end
 end
@@ -71,6 +120,11 @@ end
 eventFrame:RegisterEvent("PLAYER_LOGIN")
 function eventFrame:PLAYER_LOGIN()
     if IsInGuild() then
+        -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+        if IsCommRestricted() then
+            F.Debug("Cell: Comm suppressed - restricted context (CELL_VERSION guild)")
+            return
+        end
         Comm:SendCommMessage("CELL_VERSION", Cell.version, "GUILD", nil, "NORMAL")
     end
 end
@@ -107,6 +161,11 @@ function F.NotifyMarkLock(mark, name, class)
     F.Print(L["%s lock %s on %s."]:format(L["You"], F.GetMarkEscapeSequence(mark), name))
 
     UpdateSendChannel()
+    -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+    if IsCommRestricted() then
+        F.Debug("Cell: Comm suppressed - restricted context (CELL_MARKS lock)")
+        return
+    end
     Comm:SendCommMessage("CELL_MARKS", Serialize({true, mark, name}), sendChannel, nil, "ALERT")
 end
 
@@ -115,6 +174,11 @@ function F.NotifyMarkUnlock(mark, name, class)
     F.Print(L["%s unlock %s from %s."]:format(L["You"], F.GetMarkEscapeSequence(mark), name))
 
     UpdateSendChannel()
+    -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+    if IsCommRestricted() then
+        F.Debug("Cell: Comm suppressed - restricted context (CELL_MARKS unlock)")
+        return
+    end
     Comm:SendCommMessage("CELL_MARKS", Serialize({false, mark, name}), sendChannel, nil, "ALERT")
 end
 
@@ -167,6 +231,11 @@ function F.CheckPriority()
     -- NOTE: needs time to calc myPriority
     C_Timer.After(1, function()
         UpdateSendChannel()
+        -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+        if IsCommRestricted() then
+            F.Debug("Cell: Comm suppressed - restricted context (CELL_CPRIO chk)")
+            return
+        end
         Comm:SendCommMessage("CELL_CPRIO", "chk", sendChannel, nil, "ALERT")
     end)
     -- if t_check then t_check:Cancel() end
@@ -184,6 +253,11 @@ Comm:RegisterComm("CELL_CPRIO", function(prefix, message, channel, sender)
     if t_send then t_send:Cancel() end
     t_send = C_Timer.NewTimer(2, function()
         UpdateSendChannel()
+        -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+        if IsCommRestricted() then
+            F.Debug("Cell: Comm suppressed - restricted context (CELL_PRIO)")
+            return
+        end
         Comm:SendCommMessage("CELL_PRIO", tostring(myPriority), sendChannel, nil, "ALERT")
     end)
 end)
@@ -208,6 +282,11 @@ end)
 -- cross realm send
 -----------------------------------------
 local function CrossRealmSendCommMessage(prefix, message, playerName, priority, callbackFn)
+    -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+    if IsCommRestricted() then
+        F.Debug("Cell: Comm suppressed - restricted context (CrossRealm:", prefix, ")")
+        return
+    end
     -- NOTE: unit needs to be in your group, or it will always return true
     if UnitIsSameServer(playerName) then
         Comm:SendCommMessage(prefix, message, "WHISPER", playerName, priority, callbackFn)

--- a/Comm/Nicknames.lua
+++ b/Comm/Nicknames.lua
@@ -73,6 +73,11 @@ local function CheckNicknames()
             if nic_check then nic_check:Cancel() end
             nic_check = C_Timer.NewTimer(random(3), function()
                 UpdateSendChannel()
+                -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+                if Cell.isMidnight and F.IsCommRestricted and F.IsCommRestricted() then
+                    F.Debug("Cell: Comm suppressed - restricted context (CELL_CNIC)")
+                    return
+                end
                 Comm:SendCommMessage("CELL_CNIC", "chk", sendChannel, nil, "ALERT")
             end)
         end
@@ -160,7 +165,12 @@ local function UpdateNicknames(which, value1, value2)
             if nic_check then nic_check:Cancel() end
             -- disabled, notify others
             UpdateSendChannel()
-            Comm:SendCommMessage("CELL_NIC", "CELL_NONE", sendChannel)
+            -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+            if Cell.isMidnight and F.IsCommRestricted and F.IsCommRestricted() then
+                F.Debug("Cell: Comm suppressed - restricted context (CELL_NIC sync-off)")
+            else
+                Comm:SendCommMessage("CELL_NIC", "CELL_NONE", sendChannel)
+            end
 
             -- update all
             F.IterateAllUnitButtons(function(b)
@@ -178,7 +188,12 @@ local function UpdateNicknames(which, value1, value2)
         -- notify others
         if IsInGroup() and CellDB["nicknames"]["sync"] then
             UpdateSendChannel()
-            Comm:SendCommMessage("CELL_NIC", Cell.vars.playerNickname or "CELL_NONE", sendChannel)
+            -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+            if Cell.isMidnight and F.IsCommRestricted and F.IsCommRestricted() then
+                F.Debug("Cell: Comm suppressed - restricted context (CELL_NIC mine)")
+            else
+                Comm:SendCommMessage("CELL_NIC", Cell.vars.playerNickname or "CELL_NONE", sendChannel)
+            end
         end
 
     -- customs
@@ -218,6 +233,11 @@ Comm:RegisterComm("CELL_CNIC", function(prefix, message, channel, sender)
     if nic_send then nic_send:Cancel() end
     nic_send = C_Timer.NewTimer(3, function()
         UpdateSendChannel()
+        -- Addon comms blocked during encounters/M+/PvP on Midnight 12.0.0+
+        if Cell.isMidnight and F.IsCommRestricted and F.IsCommRestricted() then
+            F.Debug("Cell: Comm suppressed - restricted context (CELL_NIC nic_send)")
+            return
+        end
         if CellDB["nicknames"]["sync"] then
             Comm:SendCommMessage("CELL_NIC", Cell.vars.playerNickname or "CELL_NONE", sendChannel)
         else

--- a/Core.lua
+++ b/Core.lua
@@ -31,12 +31,19 @@ local P = Cell.pixelPerfectFuncs
 local L = Cell.L
 
 -- sharing version check
-Cell.MIN_VERSION = 246
-Cell.MIN_CLICKCASTINGS_VERSION = 246
-Cell.MIN_LAYOUTS_VERSION = 246
-Cell.MIN_INDICATORS_VERSION = 246
-Cell.MIN_DEBUFFS_VERSION = 246
-Cell.MIN_QUICKASSIST_VERSION = 246
+Cell.MIN_VERSION = 275
+Cell.MIN_CLICKCASTINGS_VERSION = 275
+Cell.MIN_LAYOUTS_VERSION = 275
+Cell.MIN_INDICATORS_VERSION = 275
+Cell.MIN_DEBUFFS_VERSION = 275
+Cell.MIN_QUICKASSIST_VERSION = 275
+
+-- Patch 12.0.0+ Secret Value Testing CVars (use in-game to force restrictions):
+-- /run SetCVar("secretCombatRestrictionsForced", 1)
+-- /run SetCVar("secretEncounterRestrictionsForced", 1)
+-- /run SetCVar("secretChallengeModeRestrictionsForced", 1)
+-- /run SetCVar("secretPvPMatchRestrictionsForced", 1)
+-- Reset: /run SetCVar("secretCombatRestrictionsForced", 0)
 
 --@debug@
 local debugMode = true
@@ -818,9 +825,14 @@ function eventFrame:PLAYER_LOGIN()
     Cell.vars.playerNameFull = F.UnitFullName("player")
 
     --! init bgMaxPlayers
-    for i = 1, GetNumBattlegroundTypes() do
-        local bgName, _, _, _, _, _, bgId, maxPlayers = GetBattlegroundInfo(i)
-        bgMaxPlayers[bgId] = maxPlayers
+    -- Midnight 12.0.0 removed GetBattlegroundInfo; guard for compatibility
+    if GetBattlegroundInfo then
+        for i = 1, GetNumBattlegroundTypes() do
+            local bgName, _, _, _, _, _, bgId, maxPlayers = GetBattlegroundInfo(i)
+            if bgId then
+                bgMaxPlayers[bgId] = maxPlayers
+            end
+        end
     end
 
     Cell.vars.playerGUID = UnitGUID("player")

--- a/Defaults/ClickCasting_DefaultSpells.lua
+++ b/Defaults/ClickCasting_DefaultSpells.lua
@@ -79,7 +79,7 @@ local defaultSpells = {
             "406732C", -- Spatial Paradox - 空间悖论
             "378441P", -- Time Stop - 时间停止
             -- "374348C", -- Renewing Blaze - 新生光焰
-            "443328H", -- Engulf -- 焚身
+            -- "443328H", -- Engulf -- 焚身 (removed in 12.0)
         },
         -- 1467 - Devastation
         [1467] = {
@@ -214,22 +214,22 @@ local defaultSpells = {
             17, -- Power Word: Shield - 真言术：盾
             2061, -- Flash Heal - 快速治疗
             2096, -- Mind Vision - 心灵视界
-            "139C", -- Renew - 恢复
-            "33076C", -- Prayer of Mending - 愈合祷言
+            -- "139C", -- Renew - 恢复 (removed in 12.0)
             "73325C", -- Leap of Faith - 信仰飞跃
             "10060C", -- Power Infusion - 能量灌注
-            "373481C", -- Power Word: Life - 真言术：命
-            "108968C", -- Void Shift - 虚空转移
+            -- "373481C", -- Power Word: Life - 真言术：命 (removed in 12.0)
+            -- "108968C", -- Void Shift - 虚空转移 (removed in 12.0)
         },
         -- 256 - Discipline
         [256] = {
             212036, -- Mass Resurrection - 群体复活
             527, -- Purify - 纯净术
             47540, -- Penance - 苦修
+            "200829S", -- Plea - 恳求 (added in 12.0)
             "194509S", -- Power Word: Radiance - 真言术：耀
             "33206S", -- Pain Suppression - 痛苦压制
             "47536S", -- Rapture - 全神贯注
-            "314867S", -- Shadow Covenant - 暗影盟约
+            -- "314867S", -- Shadow Covenant - 暗影盟约 (removed in 12.0)
             -- "421453S", -- Ultimate Penitence - 终极苦修
         },
         -- 257 - Holy
@@ -237,6 +237,7 @@ local defaultSpells = {
             212036, -- Mass Resurrection - 群体复活
             527, -- Purify - 纯净术
             2060, -- Heal - 治疗术
+            "33076S", -- Prayer of Mending - 愈合祷言 (moved from class to Holy in 12.0)
             "2050S", -- Holy Word: Serenity - 圣言术：静
             "596S", -- Prayer of Healing - 治疗祷言
             "47788S", -- Guardian Spirit - 守护之魂

--- a/Defaults/Indicator_Bleeds.lua
+++ b/Defaults/Indicator_Bleeds.lua
@@ -4,6 +4,10 @@ local I = Cell.iFuncs
 local bleedList
 
 function I.CheckDebuffType(debuffType, spellId)
+    -- Midnight 12.0.0+: debuffType and spellId may be secret — can't compare or use as table key
+    if issecretvalue and (issecretvalue(spellId) or issecretvalue(debuffType)) then
+        return debuffType
+    end
     if (not debuffType or debuffType == "") and bleedList[spellId] then
         return "Bleed"
     end

--- a/Defaults/Indicator_DefaultSpells.lua
+++ b/Defaults/Indicator_DefaultSpells.lua
@@ -779,6 +779,9 @@ local spells =  {
     406789, -- 空间悖论 - Spatial Paradox
     445740, -- 纵焰 - Enkindle
     409895, -- 精神之花 - Spiritbloom (Reverberations, Chronowarden Hero Talent)
+    410263, -- 炼狱祝福 - Inferno's Blessing
+    410686, -- 共生绽放 - Symbiotic Bloom
+    413984, -- 流沙 - Shifting Sands
 
     -- monk
     119611, -- 复苏之雾 - Renewing Mist
@@ -789,6 +792,7 @@ local spells =  {
     450769, -- 和谐化身 - Aspect of Harmony
     450805, -- 净化之魂 - Purified Spirit
     467281, -- 金创药 - Healing Elixir
+    115175, -- 抚慰之雾 - Soothing Mist
 
     -- paladin
     53563, -- 圣光道标 - Beacon of Light
@@ -804,9 +808,10 @@ local spells =  {
     388010, -- 暮秋祝福 - Blessing of Autumn
     388011, -- 凛冬祝福 - Blessing of Winter
     200654, -- 提尔的拯救 - Tyr's Deliverance
+    1244893, -- 救世主道标 - Beacon of the Savior
 
     -- priest
-    -- 139, -- 恢复 - Renew (removed in 12.0)
+    139, -- 恢复 - Renew
     200829, -- 恳求 - Plea (added in 12.0, Disc)
     41635, -- 愈合祷言 - Prayer of Mending
     17, -- 真言术：盾 - Power Word: Shield
@@ -814,6 +819,7 @@ local spells =  {
     77489, -- 圣光回响 - Echo of Light
     372847, -- 光明之泉恢复 - Blessed Bolt
     -- 443526, -- 慰藉预兆 - Premonition of Solace (removed in 12.0)
+    1253593, -- 虚空之盾 - Void Shield
 
     -- shaman
     974, -- 大地之盾 - Earth Shield

--- a/Defaults/Indicator_DefaultSpells.lua
+++ b/Defaults/Indicator_DefaultSpells.lua
@@ -125,14 +125,14 @@ local aoeHealings = {
     },
 
     ["PRIEST"] = {
-        [120517] = true,   -- 光晕 - Halo
+        [120517] = true,   -- 光晕 - Halo (moved to Archon hero talent in 12.0)
         [34861]  = true,   -- 圣言术：灵 - Holy Word: Sanctify
         [596]    = true,   -- 治疗祷言 - Prayer of Healing
         [64843]  = true,   -- 神圣赞美诗 - Divine Hymn
-        [110744] = true,   -- 神圣之星 - Divine Star
+        -- [110744] = true,   -- 神圣之星 - Divine Star (removed in 12.0)
         [204883] = true,   -- 治疗之环 - Circle of Healing
         [281265] = true,   -- 神圣新星 - Holy Nova
-        [314867] = true,   -- 暗影盟约 - Shadow Covenant
+        -- [314867] = true,   -- 暗影盟约 - Shadow Covenant (removed in 12.0)
         [15290]  = true,   -- 吸血鬼的拥抱 - Vampiric Embrace
         [372787] = true,   -- 神言术：佑 - Divine Word: Sanctuary
     },
@@ -143,7 +143,7 @@ local aoeHealings = {
         [108280] = true,   -- 治疗之潮图腾 (SUMMON) - Healing Tide Totem
         [52042]  = true,   -- 治疗之泉图腾 (SUMMON) - Healing Stream Totem
         [197995] = true,   -- 奔涌之流 - Wellspring
-        [157503] = true,   -- 暴雨图腾 - Cloudburst
+        -- [157503] = true,   -- 暴雨图腾 - Cloudburst (removed in 12.0)
         [114911] = true,   -- 先祖指引 - Ancestral Guidance
         [382311] = true,   -- 先祖复苏 - Ancestral Awakening
         [207778] = true,   -- 倾盆大雨 - Downpour
@@ -622,11 +622,11 @@ local dispelNodeIDs = {
 
     -- SHAMAN ---------------
         -- 262 - Elemental
-        [262] = {["Curse"] = 103608, ["Poison"] = 103609},
+        [262] = {["Curse"] = 103608, ["Poison"] = 103599},
         -- 263 - Enhancement
-        [263] = {["Curse"] = 103608, ["Poison"] = 103609},
+        [263] = {["Curse"] = 103608, ["Poison"] = 103599},
         -- 264 - Restoration
-        [264] = {["Curse"] = 81073, ["Magic"] = true, ["Poison"] = 103609},
+        [264] = {["Curse"] = 81073, ["Magic"] = true, ["Poison"] = 103599},
     -------------------------
 
     -- WARLOCK --------------
@@ -753,7 +753,7 @@ local spells =  {
     145205, -- 百花齐放 - Efflorescence
     383193, -- 林地护理 - Grove Tending
     439530, -- 共生绽华 - Symbiotic Blooms
-    429224, -- 次级塞纳里奥结界 - Minor Cenarion Ward
+    -- 429224, -- 次级塞纳里奥结界 - Minor Cenarion Ward (removed in 12.0, Durability of Nature redesigned)
 
     -- evoker
     363502, -- 梦境飞行 - Dream Flight
@@ -801,13 +801,14 @@ local spells =  {
     200654, -- 提尔的拯救 - Tyr's Deliverance
 
     -- priest
-    139, -- 恢复 - Renew
+    -- 139, -- 恢复 - Renew (removed in 12.0)
+    200829, -- 恳求 - Plea (added in 12.0, Disc)
     41635, -- 愈合祷言 - Prayer of Mending
     17, -- 真言术：盾 - Power Word: Shield
     194384, -- 救赎 - Atonement
     77489, -- 圣光回响 - Echo of Light
     372847, -- 光明之泉恢复 - Blessed Bolt
-    443526, -- 慰藉预兆 - Premonition of Solace
+    -- 443526, -- 慰藉预兆 - Premonition of Solace (removed in 12.0)
 
     -- shaman
     974, -- 大地之盾 - Earth Shield

--- a/Defaults/Indicator_DefaultSpells.lua
+++ b/Defaults/Indicator_DefaultSpells.lua
@@ -184,6 +184,7 @@ function I.UpdateAoEHealings(t)
 end
 
 function I.IsAoEHealing(name, id)
+    if issecretvalue and (issecretvalue(name) or issecretvalue(id)) then return end
     return builtInAoEHealings[name] or builtInAoEHealings[id] or customAoEHealings[id]
 end
 
@@ -338,6 +339,7 @@ end
 local UnitIsUnit = UnitIsUnit
 local bos = F.GetSpellInfo(6940) -- 牺牲祝福
 function I.IsExternalCooldown(name, id, source, target)
+    if issecretvalue and (issecretvalue(name) or issecretvalue(id)) then return end
     if name == bos then
         if source and target then
             -- NOTE: hide bos on caster
@@ -488,6 +490,7 @@ function I.UpdateDefensives(t)
 end
 
 function I.IsDefensiveCooldown(name, id)
+    if issecretvalue and (issecretvalue(name) or issecretvalue(id)) then return end
     return builtInDefensives[name] or builtInDefensives[id] or customDefensives[id]
 end
 
@@ -546,6 +549,7 @@ do
 end
 
 function I.IsTankActiveMitigation(spellId)
+    if issecretvalue and issecretvalue(spellId) then return end
     return tankActiveMitigations[spellId]
 end
 
@@ -733,6 +737,7 @@ do
 end
 
 function I.IsDrinking(name)
+    if issecretvalue and issecretvalue(name) then return end
     return drinks[name]
 end
 
@@ -1306,5 +1311,6 @@ function I.UpdateCrowdControls(t)
 end
 
 function I.IsCrowdControls(name, id)
+    if issecretvalue and (issecretvalue(name) or issecretvalue(id)) then return end
     return builtInCrowdControls[name] or builtInCrowdControls[id] or customCrowdControls[name]
 end

--- a/Defaults/Indicator_Defaults.lua
+++ b/Defaults/Indicator_Defaults.lua
@@ -267,6 +267,8 @@ end
 -- dispels: custom debuff type color
 -------------------------------------------------
 function I.GetDebuffTypeColor(debuffType)
+    -- Midnight 12.0.0+: debuffType may be secret; cannot use as table key
+    if issecretvalue and issecretvalue(debuffType) then return 0, 0, 0 end
     if debuffType and CellDB["debuffTypeColor"][debuffType] then
         return CellDB["debuffTypeColor"][debuffType]["r"], CellDB["debuffTypeColor"][debuffType]["g"],
             CellDB["debuffTypeColor"][debuffType]["b"]

--- a/Defaults/Indicator_Defaults.lua
+++ b/Defaults/Indicator_Defaults.lua
@@ -283,9 +283,21 @@ function I.SetDebuffTypeColor(debuffType, r, g, b)
     end
 end
 
+-- Midnight 12.0.0 removed the DebuffTypeColor global; provide a local fallback
+-- with the standard Blizzard debuff type colors
+local CellDebuffTypeColorFallback = {
+    ["none"]    = {r = 0.80, g = 0.00, b = 0.00},
+    ["Magic"]   = {r = 0.20, g = 0.60, b = 1.00},
+    ["Curse"]   = {r = 0.60, g = 0.00, b = 1.00},
+    ["Disease"] = {r = 0.60, g = 0.40, b = 0.00},
+    ["Poison"]  = {r = 0.00, g = 0.60, b = 0.00},
+    [""]        = {r = 0.80, g = 0.00, b = 0.00},
+}
+
 function I.ResetDebuffTypeColor()
-    -- copy
-    CellDB["debuffTypeColor"] = F.Copy(DebuffTypeColor)
+    -- copy from WoW global if available, otherwise use local fallback
+    local source = DebuffTypeColor or CellDebuffTypeColorFallback
+    CellDB["debuffTypeColor"] = F.Copy(source)
     -- add Bleed
     CellDB["debuffTypeColor"]["Bleed"] = {r = 1, g = 0.2, b = 0.6}
     -- add cleu

--- a/Defaults/LoadDefaults.xml
+++ b/Defaults/LoadDefaults.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Indicator_Defaults.lua"/>
     <Script file="Indicator_Bleeds.lua"/>
     <Script file="Indicator_DefaultSpells.lua"/>

--- a/Defaults/LoadDefaults_Cata.xml
+++ b/Defaults/LoadDefaults_Cata.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Indicator_Defaults.lua"/>
     <Script file="Indicator_Bleeds.lua"/>
     <Script file="Indicator_DefaultSpells_Cata.lua"/>

--- a/Defaults/LoadDefaults_Mists.xml
+++ b/Defaults/LoadDefaults_Mists.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Indicator_Defaults.lua"/>
     <Script file="Indicator_Bleeds.lua"/>
     <Script file="Indicator_DefaultSpells_Mists.lua"/>

--- a/Defaults/LoadDefaults_TBC.xml
+++ b/Defaults/LoadDefaults_TBC.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Indicator_Defaults.lua"/>
     <Script file="Indicator_Bleeds.lua"/>
     <Script file="Indicator_DefaultSpells_TBC.lua"/>

--- a/Defaults/LoadDefaults_Vanilla.xml
+++ b/Defaults/LoadDefaults_Vanilla.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Indicator_Defaults.lua"/>
     <Script file="Indicator_Bleeds.lua"/>
     <Script file="Indicator_DefaultSpells_Vanilla.lua"/>

--- a/Defaults/LoadDefaults_Wrath.xml
+++ b/Defaults/LoadDefaults_Wrath.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Indicator_Defaults.lua"/>
     <Script file="Indicator_Bleeds.lua"/>
     <Script file="Indicator_DefaultSpells_Wrath.lua"/>

--- a/HideBlizzard.lua
+++ b/HideBlizzard.lua
@@ -47,23 +47,30 @@ end
 function F.HideBlizzardParty()
     _G.UIParent:UnregisterEvent("GROUP_ROSTER_UPDATE")
 
+    -- Midnight 12.0.0+ may have different party frame structure
     if _G.CompactPartyFrame then
         _G.CompactPartyFrame:UnregisterAllEvents()
+        _G.CompactPartyFrame:SetParent(hiddenParent)
     end
 
     if _G.PartyFrame then
         _G.PartyFrame:UnregisterAllEvents()
         _G.PartyFrame:SetScript("OnShow", nil)
-        for frame in _G.PartyFrame.PartyMemberFramePool:EnumerateActive() do
-            HideFrame(frame)
+        if _G.PartyFrame.PartyMemberFramePool then
+            for frame in _G.PartyFrame.PartyMemberFramePool:EnumerateActive() do
+                HideFrame(frame)
+            end
         end
         HideFrame(_G.PartyFrame)
     else
+        -- Legacy party frame fallback
         for i = 1, 4 do
             HideFrame(_G["PartyMemberFrame"..i])
             HideFrame(_G["CompactPartyMemberFrame"..i])
         end
-        HideFrame(_G.PartyMemberBackground)
+        if _G.PartyMemberBackground then
+            HideFrame(_G.PartyMemberBackground)
+        end
     end
 end
 

--- a/Indicators/Actions.lua
+++ b/Indicators/Actions.lua
@@ -10,6 +10,13 @@ local orientation, speed
 -------------------------------------------------
 -- events
 -------------------------------------------------
+-- Audited for Midnight 12.0.0+ compatibility: no changes required.
+-- CLEU (COMBAT_LOG_EVENT_UNFILTERED) is not used — it is fully commented out below.
+-- The active handler listens to UNIT_SPELLCAST_SUCCEEDED for group members only.
+-- spellID from UNIT_SPELLCAST_SUCCEEDED for allied units is non-secret.
+-- Cell.vars.actions[spellID] table key usage is safe because the spellID comes
+-- from your own group's spellcasts, which are never restricted by GetRestrictedActionStatus.
+
 -- CLEU: subevent, source, target, spellId, spellName
 -- [15:10] SPELL_HEAL 秋静葉 秋静葉 6262 治疗石
 -- [15:10] SPELL_CAST_SUCCESS 秋静葉 nil 6262 治疗石

--- a/Indicators/Actions.lua
+++ b/Indicators/Actions.lua
@@ -40,6 +40,9 @@ eventFrame:SetScript("OnEvent", function(self, event, unit, castGUID, spellID)
         print("|cFFFF3030[Cell]|r |cFFB2B2B2" .. event .. ":|r", unit, "|cFF00FF00" .. (spellID or "nil") .. "|r", name)
     end
 
+    -- Midnight 12.0.0+: spellID from UNIT_SPELLCAST_SUCCEEDED is secret during restricted contexts
+    if Cell.isMidnight and issecretvalue and issecretvalue(spellID) then return end
+
     if Cell.vars.actions[spellID] then
         F.HandleUnitButton("unit", unit, Display, unpack(Cell.vars.actions[spellID]))
     end

--- a/Indicators/AoEHealing.lua
+++ b/Indicators/AoEHealing.lua
@@ -8,40 +8,44 @@ local I = Cell.iFuncs
 -------------------------------------------------
 -- CreateAoEHealing -- not support for npc
 -------------------------------------------------
-local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+-- NOTE: This indicator relied on COMBAT_LOG_EVENT_UNFILTERED (SPELL_HEAL /
+-- SPELL_PERIODIC_HEAL / SPELL_SUMMON) to detect AoE healing events.
+-- COMBAT_LOG_EVENT_UNFILTERED is removed in Midnight (WoW 12.0.0).
+-- When Cell.isMidnight is true the eventFrame is never registered, so no
+-- flash animation will trigger. The indicator frame still exists and can be
+-- re-enabled if a suitable non-CLEU API becomes available in a future build.
 
 local function Display(b)
     b.indicators.aoeHealing:Display()
 end
 
-local playerSummoned = {}
 local eventFrame = CreateFrame("Frame")
-eventFrame:SetScript("OnEvent", function()
-    local timestamp, subevent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellId, spellName = CombatLogGetCurrentEventInfo()
-    -- if subevent == "SPELL_SUMMON" then print(subevent, sourceName, sourceGUID, destName, destGUID, spellName) end
-    if subevent == "SPELL_SUMMON" then
-        -- print(sourceGUID == Cell.vars.playerGUID, destGUID, spellName, spellId)
-        if sourceGUID == Cell.vars.playerGUID and destGUID and I.IsAoEHealing(spellName, spellId) then
-            local duration = I.GetSummonDuration(spellName)
-            if duration then
-                playerSummoned[destGUID] = GetTime() + duration -- expirationTime
-                C_Timer.After(duration, function()
-                    playerSummoned[destGUID] = nil
-                end)
+
+if not Cell.isMidnight then
+    local playerSummoned = {}
+    eventFrame:SetScript("OnEvent", function()
+        local timestamp, subevent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellId, spellName = CombatLogGetCurrentEventInfo()
+        -- if subevent == "SPELL_SUMMON" then print(subevent, sourceName, sourceGUID, destName, destGUID, spellName) end
+        if subevent == "SPELL_SUMMON" then
+            if sourceGUID == Cell.vars.playerGUID and destGUID and I.IsAoEHealing(spellName, spellId) then
+                local duration = I.GetSummonDuration(spellName)
+                if duration then
+                    playerSummoned[destGUID] = GetTime() + duration -- expirationTime
+                    C_Timer.After(duration, function()
+                        playerSummoned[destGUID] = nil
+                    end)
+                end
             end
         end
-        -- texplore(playerSummoned)
-    end
-    -- if (subevent == "SPELL_HEAL" or subevent == "SPELL_PERIODIC_HEAL") then print(subevent, sourceName, sourceGUID, destName, spellId, spellName) end
-    if subevent == "SPELL_HEAL" or subevent == "SPELL_PERIODIC_HEAL" then
-        if destGUID then
-            -- print(sourceGUID == Cell.vars.playerGUID, sourceGUID, playerSummoned[sourceGUID])
-            if (sourceGUID == Cell.vars.playerGUID and I.IsAoEHealing(spellName, spellId)) or playerSummoned[sourceGUID] then
-                F.HandleUnitButton("guid", destGUID, Display)
+        if subevent == "SPELL_HEAL" or subevent == "SPELL_PERIODIC_HEAL" then
+            if destGUID then
+                if (sourceGUID == Cell.vars.playerGUID and I.IsAoEHealing(spellName, spellId)) or playerSummoned[sourceGUID] then
+                    F.HandleUnitButton("guid", destGUID, Display)
+                end
             end
         end
-    end
-end)
+    end)
+end
 
 function I.CreateAoEHealing(parent)
     local aoeHealing = CreateFrame("Frame", parent:GetName().."AoEHealing", parent.widgets.indicatorFrame)
@@ -89,6 +93,10 @@ function I.CreateAoEHealing(parent)
 end
 
 function I.EnableAoEHealing(enabled)
+    -- On Midnight (12.0.0+) COMBAT_LOG_EVENT_UNFILTERED is unavailable;
+    -- the eventFrame has no OnEvent script in that case, so registration
+    -- is intentionally skipped.
+    if Cell.isMidnight then return end
     if enabled then
         eventFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     else

--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -13,6 +13,18 @@ local P = Cell.pixelPerfectFuncs
 
 local LCG = LibStub("LibCustomGlow-1.0")
 
+-- Midnight 12.0.0+: aura count (applications) may be secret; sanitize for safe comparisons/table-key use
+local function _SanitizeCount(count)
+    if issecretvalue and issecretvalue(count) then return 0 end
+    return count or 0
+end
+
+-- Midnight 12.0.0+: helper for stack text display (most common pattern)
+local function _StackText(count)
+    count = _SanitizeCount(count)
+    return (count == 0 or count == 1) and "" or count
+end
+
 CELL_BORDER_SIZE = 1
 CELL_BORDER_COLOR = {0, 0, 0, 1}
 CELL_COOLDOWN_STYLE = "VERTICAL"
@@ -471,7 +483,7 @@ local function BorderIcon_SetCooldown(frame, start, duration, debuffType, textur
     end
 
     frame.icon:SetTexture(texture)
-    frame.stack:SetText((count == 0 or count == 1) and "" or count)
+    frame.stack:SetText(_StackText(count))
     frame:Show()
 
     if refreshing then
@@ -615,7 +627,7 @@ local function BarIcon_SetCooldown(frame, start, duration, debuffType, texture, 
     end
 
     frame.icon:SetTexture(texture)
-    frame.stack:SetText((count == 0 or count == 1) and "" or count)
+    frame.stack:SetText(_StackText(count))
     frame:Show()
 
     if refreshing then
@@ -1040,6 +1052,7 @@ local circled = {"①","②","③","④","⑤","⑥","⑦","⑧","⑨","⑩","�
 local function Text_SetCooldown(frame, start, duration, debuffType, texture, count)
     if duration == 0 then
         -- always show stack
+        count = _SanitizeCount(count)
         count = count == 0 and 1 or count
         count = frame.circledStackNums and circled[count] or count
         frame.text:SetText(count)
@@ -1055,6 +1068,7 @@ local function Text_SetCooldown(frame, start, duration, debuffType, texture, cou
         frame._duration = duration
 
         if frame.durationTbl[1] then
+            count = _SanitizeCount(count)
             if frame.showStack and count ~= 0 then
                 if frame.circledStackNums then
                     frame._count = circled[count].." "
@@ -1069,6 +1083,7 @@ local function Text_SetCooldown(frame, start, duration, debuffType, texture, cou
             frame:SetScript("OnUpdate", Text_OnUpdateDuration)
         else
             -- always show stack
+            count = _SanitizeCount(count)
             count = count == 0 and 1 or count
             if frame.circledStackNums then
                 frame.text:SetText(circled[count])
@@ -1192,7 +1207,7 @@ local function Rect_SetCooldown(frame, start, duration, debuffType, texture, cou
         frame:SetScript("OnUpdate", Rect_OnUpdate)
     end
 
-    frame.stack:SetText((count == 0 or count == 1) and "" or count)
+    frame.stack:SetText(_StackText(count))
     frame:Show()
 end
 
@@ -1324,7 +1339,7 @@ local function Bar_SetCooldown(bar, start, duration, debuffType, texture, count)
         bar:SetScript("OnUpdate", Bar_OnUpdate)
     end
 
-    bar.stack:SetText((count == 0 or count == 1) and "" or count)
+    bar.stack:SetText(_StackText(count))
     bar:Show()
 end
 
@@ -1430,7 +1445,7 @@ local function Bars_SetCooldown(bar, start, duration, debuffType, texture, count
 
     bar:SetStatusBarColor(color[1], color[2], color[3], color[4])
     bar:SetBackdropColor(color[1] * 0.2, color[2] * 0.2, color[3] * 0.2, color[4])
-    bar.stack:SetText((count == 0 or count == 1) and "" or count)
+    bar.stack:SetText(_StackText(count))
     bar:Show()
 end
 
@@ -2042,7 +2057,7 @@ local function Block_SetCooldown_Duration(frame, start, duration, debuffType, te
         frame:SetScript("OnUpdate", Block_OnUpdate_Duration)
     end
 
-    frame.stack:SetText((count == 0 or count == 1) and "" or count)
+    frame.stack:SetText(_StackText(count))
     frame:Show()
 
     if refreshing then
@@ -2116,7 +2131,7 @@ local function Block_SetCooldown_Stack(frame, start, duration, debuffType, textu
         frame:SetBackdropColor(frame.colors[2][1], frame.colors[2][2], frame.colors[2][3], frame.colors[2][4])
     end
 
-    frame.stack:SetText((count == 0 or count == 1) and "" or count)
+    frame.stack:SetText(_StackText(count))
     frame:Show()
 
     if refreshing then
@@ -2243,7 +2258,7 @@ local function Blocks_SetCooldown(frame, start, duration, debuffType, texture, c
     end
 
     frame:SetBackdropColor(color[1], color[2], color[3], color[4])
-    frame.stack:SetText((count == 0 or count == 1) and "" or count)
+    frame.stack:SetText(_StackText(count))
     frame:Show()
 
     if refreshing then

--- a/Indicators/Base.lua
+++ b/Indicators/Base.lua
@@ -7,6 +7,10 @@ local I = Cell.iFuncs
 ---@type PixelPerfectFuncs
 local P = Cell.pixelPerfectFuncs
 
+-- NOTE (Midnight 12.0.0+): Health text formatting with arithmetic on health/maxHealth
+-- is guarded for secret values in Indicators/Built-in.lua (HealthText_SetValue).
+-- All other numeric display in this file uses SetText/SetFormattedText which accept secrets.
+
 local LCG = LibStub("LibCustomGlow-1.0")
 
 CELL_BORDER_SIZE = 1
@@ -370,7 +374,7 @@ local function Icon_OnUpdate(frame, elapsed)
         if Cell.vars.iconDurationRoundUp then
             frame.duration:SetFormattedText("%d", ceil(frame._remain))
         else
-            if frame._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and frame._remain < Cell.vars.iconDurationDecimal then
                 frame.duration:SetFormattedText("%.1f", frame._remain)
             else
                 frame.duration:SetFormattedText("%d", frame._remain)
@@ -1148,7 +1152,7 @@ local function Rect_OnUpdate(frame, elapsed)
         if Cell.vars.iconDurationRoundUp then
             frame.duration:SetFormattedText("%d", ceil(frame._remain))
         else
-            if frame._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and frame._remain < Cell.vars.iconDurationDecimal then
                 frame.duration:SetFormattedText("%.1f", frame._remain)
             else
                 frame.duration:SetFormattedText("%d", frame._remain)
@@ -1274,7 +1278,7 @@ local function Bar_OnUpdate(bar, elapsed)
         if Cell.vars.iconDurationRoundUp then
             bar.duration:SetFormattedText("%d", ceil(bar._remain))
         else
-            if bar._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and bar._remain < Cell.vars.iconDurationDecimal then
                 bar.duration:SetFormattedText("%.1f", bar._remain)
             else
                 bar.duration:SetFormattedText("%d", bar._remain)
@@ -1380,7 +1384,7 @@ local function Bars_OnUpdate(bar, elapsed)
         if Cell.vars.iconDurationRoundUp then
             bar.duration:SetFormattedText("%d", ceil(bar._remain))
         else
-            if bar._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and bar._remain < Cell.vars.iconDurationDecimal then
                 bar.duration:SetFormattedText("%.1f", bar._remain)
             else
                 bar.duration:SetFormattedText("%d", bar._remain)
@@ -1988,7 +1992,7 @@ local function Block_OnUpdate_Duration(frame, elapsed)
         if Cell.vars.iconDurationRoundUp then
             frame.duration:SetFormattedText("%d", ceil(frame._remain))
         else
-            if frame._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and frame._remain < Cell.vars.iconDurationDecimal then
                 frame.duration:SetFormattedText("%.1f", frame._remain)
             else
                 frame.duration:SetFormattedText("%d", frame._remain)
@@ -2062,7 +2066,7 @@ local function Block_OnUpdate_Stack(frame, elapsed)
         if Cell.vars.iconDurationRoundUp then
             frame.duration:SetFormattedText("%d", ceil(frame._remain))
         else
-            if frame._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and frame._remain < Cell.vars.iconDurationDecimal then
                 frame.duration:SetFormattedText("%.1f", frame._remain)
             else
                 frame.duration:SetFormattedText("%d", frame._remain)
@@ -2198,7 +2202,7 @@ local function Blocks_OnUpdate(frame, elapsed)
         if Cell.vars.iconDurationRoundUp then
             frame.duration:SetFormattedText("%d", ceil(frame._remain))
         else
-            if frame._remain < Cell.vars.iconDurationDecimal then
+            if Cell.vars.iconDurationDecimal and frame._remain < Cell.vars.iconDurationDecimal then
                 frame.duration:SetFormattedText("%.1f", frame._remain)
             else
                 frame.duration:SetFormattedText("%d", frame._remain)

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1539,6 +1539,17 @@ local function HealthText_SetFormat(self, format)
 end
 
 local function HealthText_SetValue(self, health, maxHealth, shields, healAbsorbs)
+    -- On Midnight 12.0.0+, health/maxHealth may be secret values in restricted contexts.
+    -- Arithmetic (/, *, -, comparison) on secret values causes errors.
+    -- AbbreviateNumbers() and FontString:SetText() accept secret values safely.
+    -- DO NOT divide, multiply, or compare secret values.
+    if Cell.isMidnight and F.IsAuraRestricted and F.IsAuraRestricted() then
+        local healthStr = AbbreviateNumbers and AbbreviateNumbers(health) or tostring(health)
+        self.text:SetText(healthStr)
+        self:SetWidth(self.text:GetStringWidth())
+        return
+    end
+
     maxHealth = maxHealth == 0 and 1 or maxHealth
 
     self.text:SetFormattedText("%s%s%s%s",

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -777,6 +777,9 @@ eventFrame:SetScript("OnEvent", function()
 end)
 
 local function CheckCondition(operator, checkedValue, currentValue)
+    -- Midnight 12.0.0+: applications (count) may be secret even when spellId is not;
+    -- comparisons on secret values throw errors
+    if issecretvalue and (issecretvalue(currentValue) or issecretvalue(checkedValue)) then return end
     if operator == "=" then
         if currentValue == checkedValue then return true end
     elseif operator == ">" then
@@ -793,6 +796,8 @@ local function CheckCondition(operator, checkedValue, currentValue)
 end
 
 function I.GetDebuffOrder(spellName, spellId, count)
+    -- Midnight 12.0.0+: spellId/spellName may be secret; cannot use as table key
+    if issecretvalue and (issecretvalue(spellId) or issecretvalue(spellName)) then return end
     local t = currentAreaDebuffs[spellId] or currentAreaDebuffs[spellName]
     if not t then return end
 
@@ -808,6 +813,8 @@ function I.GetDebuffOrder(spellName, spellId, count)
 end
 
 function I.GetDebuffGlow(spellName, spellId, count)
+    -- Midnight 12.0.0+: spellId/spellName may be secret; cannot use as table key
+    if issecretvalue and (issecretvalue(spellId) or issecretvalue(spellName)) then return end
     local t = currentAreaDebuffs[spellId] or currentAreaDebuffs[spellName]
     if not t then return end
 
@@ -828,6 +835,8 @@ function I.GetDebuffGlow(spellName, spellId, count)
 end
 
 function I.IsDebuffUseElapsedTime(spellName, spellId)
+    -- Midnight 12.0.0+: spellId/spellName may be secret; cannot use as table key
+    if issecretvalue and (issecretvalue(spellId) or issecretvalue(spellName)) then return end
     local t = currentAreaDebuffs[spellId] or currentAreaDebuffs[spellName]
     if not t then return end
 

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1367,14 +1367,19 @@ local function StatusText_ShowTimer(self)
 
     self.timer:Show()
 
-    if not startTimeCache[self.parent.states.guid] then startTimeCache[self.parent.states.guid] = GetTime() end
+    -- Midnight 12.0.0+: guid may be secret for NPC/boss units
+    local showGuid = self.parent.states.guid
+    if not (issecretvalue and issecretvalue(showGuid)) then
+        if showGuid and not startTimeCache[showGuid] then startTimeCache[showGuid] = GetTime() end
+    end
 
     self.ticker = C_Timer.NewTicker(1, function()
         if not self.parent.states.guid and self.parent.states.unit then -- ElvUI AFK mode
             self.parent.states.guid = UnitGUID(self.parent.states.unit)
         end
-        if self.parent.states.guid and startTimeCache[self.parent.states.guid] then
-            self.timer:SetFormattedText(F.FormatTime(GetTime() - startTimeCache[self.parent.states.guid]))
+        local tickGuid = self.parent.states.guid
+        if tickGuid and not (issecretvalue and issecretvalue(tickGuid)) and startTimeCache[tickGuid] then
+            self.timer:SetFormattedText(F.FormatTime(GetTime() - startTimeCache[tickGuid]))
         else
             self.timer:SetText("")
         end
@@ -1386,7 +1391,11 @@ local function StatusText_HideTimer(self, reset)
     self.timer:SetText("")
     if reset then
         if self.ticker then self.ticker:Cancel() end
-        startTimeCache[self.parent.states.guid] = nil
+        -- Midnight 12.0.0+: guid may be secret for NPC/boss units
+        local guid = self.parent.states.guid
+        if guid and not (issecretvalue and issecretvalue(guid)) then
+            startTimeCache[guid] = nil
+        end
     end
 end
 

--- a/Indicators/Custom.lua
+++ b/Indicators/Custom.lua
@@ -255,7 +255,8 @@ end
 function I.UpdateCustomIndicators(unitButton, auraInfo)
     local unit = unitButton.states.displayedUnit
 
-    -- Midnight 12.0.0+: aura fields may be secret — bail early if so
+    -- Midnight 12.0.0+: bail only if aura type (isHelpful) is secret — we need it to classify buff/debuff.
+    -- spellId may still be secret for some auras even with hotfix; don't bail on spellId.
     if issecretvalue and issecretvalue(auraInfo.isHelpful) then return end
 
     local auraType = auraInfo.isHelpful and "buff" or "debuff"
@@ -263,12 +264,13 @@ function I.UpdateCustomIndicators(unitButton, auraInfo)
     local debuffType = auraInfo.isHarmful and (auraInfo.dispelName or "") or nil
     local count = auraInfo.applications
     local duration = auraInfo.duration
+    -- Use per-aura check for duration: non-secret auras get real timers, secret ones get zeroed.
     local start
-    if Cell.isMidnight and issecretvalue and issecretvalue(auraInfo.expirationTime) then
+    if F.IsAuraNonSecret(auraInfo) then
+        start = (auraInfo.expirationTime or 0) - auraInfo.duration
+    else
         start = 0
         duration = 0
-    else
-        start = (auraInfo.expirationTime or 0) - auraInfo.duration
     end
     local castByMe = auraInfo.sourceUnit == "player" or auraInfo.sourceUnit == "pet"
 

--- a/Indicators/Custom.lua
+++ b/Indicators/Custom.lua
@@ -5,6 +5,15 @@ local F = Cell.funcs
 ---@class CellIndicatorFuncs
 local I = Cell.iFuncs
 
+-- NOTE for Custom Indicator authors (Midnight 12.0.0+):
+-- In restricted contexts (encounters, M+, PvP, combat), aura data fields
+-- (spellId, expirationTime, applications, icon, etc.) are Secret Values.
+-- - DO NOT compare secret values with == or use arithmetic on them
+-- - DO NOT use secret values as table keys
+-- - FontString:SetText() and SetTexture() ACCEPT secrets safely
+-- - Use issecretvalue(val) to check if a value is secret
+-- - Use GetRestrictedActionStatus(0) to check if aura access is restricted
+
 -------------------------------------------------
 -- custom indicators
 -------------------------------------------------

--- a/Indicators/Custom.lua
+++ b/Indicators/Custom.lua
@@ -255,12 +255,21 @@ end
 function I.UpdateCustomIndicators(unitButton, auraInfo)
     local unit = unitButton.states.displayedUnit
 
+    -- Midnight 12.0.0+: aura fields may be secret — bail early if so
+    if issecretvalue and issecretvalue(auraInfo.isHelpful) then return end
+
     local auraType = auraInfo.isHelpful and "buff" or "debuff"
     local icon = auraInfo.icon
     local debuffType = auraInfo.isHarmful and (auraInfo.dispelName or "") or nil
     local count = auraInfo.applications
     local duration = auraInfo.duration
-    local start = (auraInfo.expirationTime or 0) - auraInfo.duration
+    local start
+    if Cell.isMidnight and issecretvalue and issecretvalue(auraInfo.expirationTime) then
+        start = 0
+        duration = 0
+    else
+        start = (auraInfo.expirationTime or 0) - auraInfo.duration
+    end
     local castByMe = auraInfo.sourceUnit == "player" or auraInfo.sourceUnit == "pet"
 
     -- check Bleed

--- a/Indicators/Custom.lua
+++ b/Indicators/Custom.lua
@@ -261,7 +261,9 @@ function I.UpdateCustomIndicators(unitButton, auraInfo)
 
     local auraType = auraInfo.isHelpful and "buff" or "debuff"
     local icon = auraInfo.icon
-    local debuffType = auraInfo.isHarmful and (auraInfo.dispelName or "") or nil
+    -- Midnight 12.0.0+: dispelName may be secret; sanitize to avoid table-key/comparison crashes downstream
+    local rawDispelName = auraInfo.dispelName
+    local debuffType = auraInfo.isHarmful and ((rawDispelName and (not issecretvalue or not issecretvalue(rawDispelName))) and rawDispelName or "") or nil
     local count = auraInfo.applications
     local duration = auraInfo.duration
     -- Use per-aura check for duration: non-secret auras get real timers, secret ones get zeroed.
@@ -288,7 +290,8 @@ function I.UpdateCustomIndicators(unitButton, auraInfo)
                 spell = auraInfo.spellId
             end
 
-            if indicatorTable["auras"][spell] or (indicatorTable["auras"][0] and duration ~= 0) then -- is in indicator spell list
+            -- Midnight 12.0.0+: spell (name or spellId) may be secret; cannot use as table key
+            if spell and (not issecretvalue or not issecretvalue(spell)) and indicatorTable["auras"][spell] or (indicatorTable["auras"][0] and duration ~= 0) then -- is in indicator spell list
                 -- check caster
                 if (indicatorTable["castBy"] == "me" and castByMe) or (indicatorTable["castBy"] == "others" and not castByMe) or (indicatorTable["castBy"] == "anyone") then
                     if auraType == "buff" then

--- a/Indicators/StatusIcon.lua
+++ b/Indicators/StatusIcon.lua
@@ -76,6 +76,8 @@ else
         if event == "UNIT_AURA" then
             local guid = UnitGUID(unit)
             if not guid then return end
+            -- Midnight 12.0.0+: UnitGUID may return secret strings for non-group units
+            if issecretvalue and issecretvalue(guid) then return end
             -- Check if soulstone buff is now absent but was present
             -- (simple: after UNIT_AURA fires, see if unit still has it)
             local hasSoulstone = F.FindAuraByName and F.FindAuraByName(unit, "BUFF", SOULSTONE)
@@ -92,6 +94,8 @@ else
         elseif event == "UNIT_HEALTH" then
             local guid = UnitGUID(unit)
             if not guid then return end
+            -- Midnight 12.0.0+: UnitGUID may return secret strings for non-group units
+            if issecretvalue and issecretvalue(guid) then return end
             if UnitIsDeadOrGhost(unit) then
                 if soulstones[guid] then
                     F.HandleUnitButton("unit", unit, DiedWithSoulstone)
@@ -207,6 +211,12 @@ function I.UpdateStatusIcon_Resurrection(button, start, duration)
     end
 
     if not start then
+        -- Midnight 12.0.0+: AuraUtil.FindAura/UnpackAuraData fails on secret aura data
+        -- F.IsAuraRestricted() is unreliable; skip entirely on Midnight
+        if Cell.isMidnight then
+            resurrectionIcon:Hide()
+            return
+        end
         local dur, expir = select(5, F.FindAuraById(unit, "DEBUFF", 160029)) -- battle res
         if dur then --! check Resurrecting debuff
             start = expir - dur

--- a/Indicators/StatusIcon.lua
+++ b/Indicators/StatusIcon.lua
@@ -26,34 +26,84 @@ local soulstones = {}
 local SOULSTONE = F.GetSpellInfo(20707)
 local RESURRECTING = F.GetSpellInfo(160029)
 
+-- NOTE: The cleuFrame previously relied on COMBAT_LOG_EVENT_UNFILTERED for:
+--   1. SPELL_AURA_REMOVED (soulstone / Resurrecting debuff removal)
+--   2. UNIT_DIED sub-event (to detect soulstone deaths)
+--   3. SPELL_RESURRECT (to detect incoming resurrections)
+-- COMBAT_LOG_EVENT_UNFILTERED is removed in Midnight (WoW 12.0.0).
+--
+-- Midnight replacements:
+--   - Incoming resurrection: already handled via INCOMING_RESURRECT_CHANGED
+--     in eventFrame + UnitHasIncomingResurrection() in I.UpdateStatusIcon.
+--   - Resurrecting debuff removal: handled by UNIT_AURA → UpdateStatusIcon_Resurrection
+--     which re-checks F.FindAuraById for the Resurrecting debuff.
+--   - Soulstone death detection: tracked via UNIT_AURA (soulstone buff removal)
+--     combined with UNIT_HEALTH + UnitIsDeadOrGhost() for the death signal.
 local cleuFrame = CreateFrame("Frame")
-cleuFrame:SetScript("OnEvent", function()
-    local timestamp, subEvent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellId, spellName = CombatLogGetCurrentEventInfo()
 
-    if subEvent == "SPELL_AURA_REMOVED" then
-        if spellName == SOULSTONE then
-            -- print("soulstone removed", timestamp, destName)
-            soulstones[destGUID] = timestamp
-            C_Timer.After(0.1, function()
-                soulstones[destGUID] = nil
-            end)
-        elseif spellName == RESURRECTING then
-            rez[destGUID] = nil
-            F.HandleUnitButton("guid", destGUID, I.UpdateStatusIcon_Resurrection)
-        end
-    elseif subEvent == "UNIT_DIED" then
-        -- print("died", timestamp, destName)
-        if soulstones[destGUID] then
-            F.HandleUnitButton("guid", destGUID, DiedWithSoulstone)
-        end
-        soulstones[destGUID] = nil
-    elseif subEvent == "SPELL_RESURRECT" then
-        local start, duration = GetTime(), 60
-        rez[destGUID] = {start, duration}
+if not Cell.isMidnight then
+    cleuFrame:SetScript("OnEvent", function()
+        local timestamp, subEvent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellId, spellName = CombatLogGetCurrentEventInfo()
 
-        F.HandleUnitButton("guid", destGUID, I.UpdateStatusIcon_Resurrection, start, duration)
-    end
-end)
+        if subEvent == "SPELL_AURA_REMOVED" then
+            if spellName == SOULSTONE then
+                soulstones[destGUID] = timestamp
+                C_Timer.After(0.1, function()
+                    soulstones[destGUID] = nil
+                end)
+            elseif spellName == RESURRECTING then
+                rez[destGUID] = nil
+                F.HandleUnitButton("guid", destGUID, I.UpdateStatusIcon_Resurrection)
+            end
+        elseif subEvent == "UNIT_DIED" then
+            if soulstones[destGUID] then
+                F.HandleUnitButton("guid", destGUID, DiedWithSoulstone)
+            end
+            soulstones[destGUID] = nil
+        elseif subEvent == "SPELL_RESURRECT" then
+            local start, duration = GetTime(), 60
+            rez[destGUID] = {start, duration}
+
+            F.HandleUnitButton("guid", destGUID, I.UpdateStatusIcon_Resurrection, start, duration)
+        end
+    end)
+else
+    -- Midnight path: detect soulstone deaths via UNIT_AURA + UNIT_HEALTH.
+    -- UNIT_AURA fires when any aura is added/removed on a tracked unit.
+    -- We watch for soulstone buff removal and immediately note the guid;
+    -- then UNIT_HEALTH (UnitIsDeadOrGhost) confirms the death.
+    cleuFrame:SetScript("OnEvent", function(self, event, unit)
+        if event == "UNIT_AURA" then
+            local guid = UnitGUID(unit)
+            if not guid then return end
+            -- Check if soulstone buff is now absent but was present
+            -- (simple: after UNIT_AURA fires, see if unit still has it)
+            local hasSoulstone = F.FindAuraByName and F.FindAuraByName(unit, "BUFF", SOULSTONE)
+            if not hasSoulstone and soulstones[guid] then
+                -- aura gone; keep window open for death
+                C_Timer.After(0.1, function()
+                    soulstones[guid] = nil
+                end)
+            elseif hasSoulstone then
+                soulstones[guid] = GetTime()
+            end
+            -- Also refresh rez icon in case Resurrecting debuff changed
+            F.HandleUnitButton("unit", unit, I.UpdateStatusIcon_Resurrection)
+        elseif event == "UNIT_HEALTH" then
+            local guid = UnitGUID(unit)
+            if not guid then return end
+            if UnitIsDeadOrGhost(unit) then
+                if soulstones[guid] then
+                    F.HandleUnitButton("unit", unit, DiedWithSoulstone)
+                end
+                soulstones[guid] = nil
+            else
+                -- unit came back alive; clear soulstone state
+                soulstones[guid] = nil
+            end
+        end
+    end)
+end
 
 -------------------------------------------------
 -- create
@@ -322,8 +372,18 @@ function I.EnableStatusIcon(enabled)
         if Cell.isRetail and CELL_SUMMON_ICONS_ENABLED then
             eventFrame:RegisterEvent("INCOMING_SUMMON_CHANGED")
         end
-        -- resurrection
-        cleuFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        -- resurrection / soulstone tracking
+        if not Cell.isMidnight then
+            -- Pre-Midnight: use CLEU for soulstone removal, UNIT_DIED, SPELL_RESURRECT
+            cleuFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        else
+            -- Midnight (12.0.0+): COMBAT_LOG_EVENT_UNFILTERED unavailable.
+            -- Use UNIT_AURA for soulstone buff tracking and UNIT_HEALTH for
+            -- death detection. INCOMING_RESURRECT_CHANGED (above) handles
+            -- incoming rez detection via UnitHasIncomingResurrection().
+            cleuFrame:RegisterEvent("UNIT_AURA")
+            cleuFrame:RegisterEvent("UNIT_HEALTH")
+        end
     else
         eventFrame:UnregisterAllEvents()
         cleuFrame:UnregisterAllEvents()

--- a/Indicators/TargetCounter.lua
+++ b/Indicators/TargetCounter.lua
@@ -63,7 +63,10 @@ local function StartTicker()
         for unit in pairs(nameplates) do
             local target = UnitGUID(unit.."target")
 
-            if not target then -- no target
+            -- Midnight 12.0.0+: UnitGUID for nameplate targets may return secret strings
+            if Cell.isMidnight and issecretvalue and issecretvalue(target) then
+                nameplateTargets[unit] = nil
+            elseif not target then -- no target
                 nameplateTargets[unit] = nil
             elseif not Cell.vars.guids[target] then -- target doesn't exists in player's group
                 nameplateTargets[unit] = nil

--- a/Indicators/TargetedSpells.lua
+++ b/Indicators/TargetedSpells.lua
@@ -141,6 +141,15 @@ end
 local function CheckUnitCast(sourceUnit, isRecheck)
     if not UnitIsEnemy("player", sourceUnit) then return end
 
+    -- On Midnight 12.0.0+, enemy spellcast info is secret in instances
+    -- Player's own casts (and pets) are always non-secret
+    if Cell.isMidnight then
+        local isPlayerCast = (sourceUnit == "player" or sourceUnit == "pet" or sourceUnit == "vehicle")
+        if not isPlayerCast and F.IsAuraRestricted and F.IsAuraRestricted() then
+            return -- skip enemy spell tracking during restricted periods
+        end
+    end
+
     local sourceGUID = UnitGUID(sourceUnit)
     local targetGUID
     local previousTarget, isChanneling

--- a/Indicators/TargetedSpells.lua
+++ b/Indicators/TargetedSpells.lua
@@ -151,6 +151,8 @@ local function CheckUnitCast(sourceUnit, isRecheck)
     end
 
     local sourceGUID = UnitGUID(sourceUnit)
+    -- Midnight 12.0.0+: UnitGUID for nameplates may return secret strings
+    if Cell.isMidnight and issecretvalue and issecretvalue(sourceGUID) then return end
     local targetGUID
     local previousTarget, isChanneling
 
@@ -273,6 +275,8 @@ eventFrame:SetScript("OnEvent", function(_, event, sourceUnit)
 
     elseif event == "UNIT_SPELLCAST_STOP" or event == "UNIT_SPELLCAST_INTERRUPTED" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_CHANNEL_STOP" then
         local sourceGUID = UnitGUID(sourceUnit)
+        -- Midnight 12.0.0+: UnitGUID may return secret strings — can't use as table key
+        if issecretvalue and issecretvalue(sourceGUID) then return end
         if casts[sourceGUID] then
             previousTarget = casts[sourceGUID]["targetGUID"]
             casts[sourceGUID] = nil
@@ -281,6 +285,8 @@ eventFrame:SetScript("OnEvent", function(_, event, sourceUnit)
 
     elseif event == "NAME_PLATE_UNIT_REMOVED" then
         local sourceGUID = UnitGUID(sourceUnit)
+        -- Midnight 12.0.0+: UnitGUID may return secret strings — can't use as table key
+        if issecretvalue and issecretvalue(sourceGUID) then return end
         if casts[sourceGUID] and not casts[sourceGUID]["nonNameplate"] then
             previousTarget = casts[sourceGUID]["targetGUID"]
             casts[sourceGUID] = nil

--- a/Libs/LibGroupInfo.lua
+++ b/Libs/LibGroupInfo.lua
@@ -598,6 +598,8 @@ end
 
 function frame:UNIT_LEVEL(unit)
     local guid = UnitGUID(unit)
+    -- Midnight 12.0.0+: nameplate GUIDs may be secret; cannot use as table key
+    if not guid or (issecretvalue and issecretvalue(guid)) then return end
     if cache[guid] then
         cache[guid].level = UnitLevel(unit)
     end

--- a/Locales/LoadLocales.xml
+++ b/Locales/LoadLocales.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="enUS.lua"/>
     <Script file="zhCN.lua"/>
     <Script file="zhTW.lua"/>

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -89,6 +89,57 @@ select(2, ...).L = setmetatable({
         <h2>If there are any issues after an update, check through all code snippets first.</h2>
         <br/>
 
+        <h1>r275.5 Added Midnight Raid Debuffs</h1>
+        <h2>Raid Debuffs</h2>
+        <p>+ Added initial Midnight expansion raid debuffs for all 12 instances (6 raids, 6 dungeons) and 41 bosses.</p>
+        <p>* Boss ability spell IDs sourced from the Encounter Journal via wago.tools DB2 tables.</p>
+        <p>! General (trash mob) debuffs still need to be collected in-game and added in a future update.</p>
+        <p>! Spells may need further in-game curation to filter out non-debuff abilities.</p>
+        <br/>
+
+        <h1>r275-release — WoW 12.0.0 (Midnight) Compatibility</h1>
+        <h2>Secret Values (12.0.0+)</h2>
+        <p>+ Added Cell.isMidnight detection flag and F.IsSecretValue(), F.IsAuraRestricted(), F.IsCooldownRestricted() utility functions.</p>
+        <p>+ Added per-aura F.IsAuraNonSecret(), F.IsSpellAuraNonSecret(), F.IsValueNonSecret() helpers — non-secret (whitelisted) auras now get real countdown timers, source detection, and duration display; secret auras gracefully degrade.</p>
+        <p>* UnitButton: major dual-path refactor — Midnight uses UnitHealPredictionCalculator, C_CurveUtil.CreateCurve(), and StatusBar overlays for health/prediction/shields; pre-Midnight retains arithmetic-based paths.</p>
+        <p>* Appearance: IncomingHeal widget uses SetStatusBarTexture on Midnight (StatusBar) vs SetTexture pre-Midnight (Texture).</p>
+        <p>* Indicator_Defaults: local DebuffTypeColor fallback for when the WoW global is removed.</p>
+        <p>* Per-field F.IsValueNonSecret() guards before every arithmetic operation on temporal aura fields (expirationTime, duration, applications).</p>
+        <h2>CLEU Removal</h2>
+        <p>- AoEHealing: disabled on Midnight (CLEU unavailable).</p>
+        <p>* StatusIcon: soulstone/resurrection tracking switches to UNIT_AURA + UNIT_HEALTH on Midnight.</p>
+        <p>* NPCFrame: boss6-8 health/aura tracking switches to unit events on Midnight.</p>
+        <p>* DeathReport: full refactor — Midnight uses UNIT_HEALTH + UnitIsDeadOrGhost() for death detection.</p>
+        <p>* UnitButton: removed CombatLogGetCurrentEventInfo dependency and CheckCLEURequired.</p>
+        <p>- General: removed useCleuHealthUpdater checkbox (CLEU health updater obsolete).</p>
+        <p>* Revise: r275 migration removes useCleuHealthUpdater from saved variables.</p>
+        <h2>Comm Restrictions</h2>
+        <p>+ Comm: IsCommRestricted() detects encounters/M+/PvP; all SendCommMessage calls guarded; pending queue with flush on ENCOUNTER_END.</p>
+        <p>+ Nicknames: all nickname sync sends guarded with F.IsCommRestricted().</p>
+        <h2>Heal Prediction &amp; Health Bar Fixes</h2>
+        <p>* Created a dedicated healPredictionCalculator separate from the shared healthCalculator — fixes corrupted health/absorb reads.</p>
+        <p>* Incoming heal bar is now a StatusBar (instead of Texture) anchored to the health fill texture edge.</p>
+        <p>* Fixed health bar loss color stuck on white/full-health — healthPercent now populated from calculator:GetCurrentHealthPercent().</p>
+        <p>* Dispels now show correctly in combat.</p>
+        <h2>Spell &amp; Default Updates</h2>
+        <p>- Removed: Engulf, Renew, Power Word: Life, Void Shift, Shadow Covenant, Divine Star, Cloudburst Totem, Minor Cenarion Ward, Premonition of Solace.</p>
+        <p>+ Added: Plea (200829, Disc Priest).</p>
+        <p>+ Added missing healing spells to default indicator list (Evoker, Monk, Paladin, Priest).</p>
+        <p>* Moved: Prayer of Mending from class-wide to Holy spec only.</p>
+        <p>* Fixed: Shaman Poison dispel node IDs (103609 → 103599).</p>
+        <h2>Defensive Nil Guards &amp; Fixes</h2>
+        <p>* MainFrame: nil guards for currentLayoutTable and tooltipPoint.</p>
+        <p>* HideBlizzard: guards for PartyMemberFramePool, CompactPartyFrame, PartyMemberBackground.</p>
+        <p>* RaidDebuffs: nil guard for encounter journal expansion data.</p>
+        <p>* TargetedSpells: skip enemy spell tracking during restricted periods.</p>
+        <p>* BuffTracker: guard GetAuraDataBySpellName when auras are restricted; per-aura sourceUnit check.</p>
+        <p>* QuickCast: skip only secret auras in ForEachAura.</p>
+        <p>* Appearance: ticker nil guard in preview OnHide.</p>
+        <h2>Infrastructure</h2>
+        <p>* All 22 XML files updated from FrameXML/UI_shared.xsd → Blizzard_SharedXML/UI.xsd.</p>
+        <p>* Core: version constants bumped to 275, GetBattlegroundInfo guard added.</p>
+        <br/>
+
         <h1>r274-release (2026-01-22 19:07 GMT+8)</h1>
         <p>* Update Molten Core debuffs (thanks Rurutia).</p>
         <p>* Fixed an issue with getting hostile boss frames via LibGetFrame.</p>

--- a/Modules/Appearance/Appearance.lua
+++ b/Modules/Appearance/Appearance.lua
@@ -496,7 +496,11 @@ local function UpdatePreviewButton(which)
         previewButton.widgets.healthBarLoss:SetTexture(Cell.vars.texture)
         previewButton.widgets.powerBar:SetStatusBarTexture(Cell.vars.texture)
         previewButton.widgets.powerBarLoss:SetTexture(Cell.vars.texture)
-        previewButton.widgets.incomingHeal:SetTexture(Cell.vars.texture)
+        if Cell.isMidnight then
+            previewButton.widgets.incomingHeal:SetStatusBarTexture(Cell.vars.texture)
+        else
+            previewButton.widgets.incomingHeal:SetTexture(Cell.vars.texture)
+        end
         previewButton.widgets.damageFlashTex:SetTexture(Cell.vars.texture)
 
         previewButton2.widgets.healthBar:SetStatusBarTexture(Cell.vars.texture)
@@ -505,7 +509,11 @@ local function UpdatePreviewButton(which)
         previewButton2.widgets.powerBar:SetStatusBarTexture(Cell.vars.texture)
         previewButton2.widgets.powerBar:GetStatusBarTexture():SetDrawLayer("ARTWORK", -7) --! VERY IMPORTANT
         previewButton2.widgets.powerBarLoss:SetTexture(Cell.vars.texture)
-        previewButton2.widgets.incomingHeal:SetTexture(Cell.vars.texture)
+        if Cell.isMidnight then
+            previewButton2.widgets.incomingHeal:SetStatusBarTexture(Cell.vars.texture)
+        else
+            previewButton2.widgets.incomingHeal:SetTexture(Cell.vars.texture)
+        end
         previewButton2.widgets.damageFlashTex:SetTexture(Cell.vars.texture)
     end
 

--- a/Modules/Appearance/Appearance.lua
+++ b/Modules/Appearance/Appearance.lua
@@ -421,8 +421,10 @@ local function CreatePreviewButtons()
 
     previewButton:SetScript("OnHide", function()
         previewButton.perc = 100
-        ticker:Cancel()
-        ticker = nil
+        if ticker then
+            ticker:Cancel()
+            ticker = nil
+        end
     end)
 
     Cell.Fire("CreatePreview", previewButton, previewButton2)

--- a/Modules/General/General.lua
+++ b/Modules/General/General.lua
@@ -303,10 +303,10 @@ end
 -------------------------------------------------
 -- misc
 -------------------------------------------------
-local alwaysUpdateAurasCB, useCleuCB, translitCB
+local alwaysUpdateAurasCB, translitCB
 
 local function CreateMiscPane()
-    local miscPane = Cell.CreateTitledPane(generalTab, L["Misc"], 205, 130)
+    local miscPane = Cell.CreateTitledPane(generalTab, L["Misc"], 205, 105)
     miscPane:SetPoint("TOPLEFT", generalTab, 222, -300)
 
     alwaysUpdateAurasCB = Cell.CreateCheckButton(miscPane, L["Always Update Auras"], function(checked, self)
@@ -316,17 +316,14 @@ local function CreateMiscPane()
     alwaysUpdateAurasCB:SetPoint("TOPLEFT", 5, -27)
     alwaysUpdateAurasCB:SetEnabled(Cell.isMists)
 
-    useCleuCB = Cell.CreateCheckButton(miscPane, L["Faster Health Updates"], function(checked, self)
-        CellDB["general"]["useCleuHealthUpdater"] = checked
-        Cell.Fire("UpdateCLEU")
-    end, "|cffff2727"..L["HIGH CPU USAGE"].." (EXPERIMENTAL)", L["Use CLEU events to increase health update rate"])
-    useCleuCB:SetPoint("TOPLEFT", alwaysUpdateAurasCB, "BOTTOMLEFT", 0, -9)
+    -- NOTE: useCleuHealthUpdater (Faster Health Updates) was removed in r275.
+    -- CLEU-based health updates are not available in Midnight 12.0.0+.
 
     translitCB = Cell.CreateCheckButton(miscPane, L["Translit Cyrillic to Latin"], function(checked, self)
         CellDB["general"]["translit"] = checked
         Cell.Fire("TranslitNames")
     end)
-    translitCB:SetPoint("TOPLEFT", useCleuCB, "BOTTOMLEFT", 0, -9)
+    translitCB:SetPoint("TOPLEFT", alwaysUpdateAurasCB, "BOTTOMLEFT", 0, -9)
 end
 
 -------------------------------------------------
@@ -522,7 +519,6 @@ local function ShowTab(tab)
         -- misc
         alwaysUpdateAurasCB:SetChecked(CellDB["general"]["alwaysUpdateAuras"])
         framePriorityWidget:Load(CellDB["general"]["framePriority"])
-        useCleuCB:SetChecked(CellDB["general"]["useCleuHealthUpdater"])
         translitCB:SetChecked(CellDB["general"]["translit"])
 
     else

--- a/Modules/RaidDebuffs/RaidDebuffs.lua
+++ b/Modules/RaidDebuffs/RaidDebuffs.lua
@@ -393,9 +393,10 @@ local function CreateWidgets()
     local expansionItems = {}
     for i = EJ_GetNumTiers(), 1, -1 do
         local eName = EJ_GetTierInfo(i)
+        local ejList = encounterJournalList[eName]
         tinsert(expansionItems, {
             ["text"] = eName,
-            ["disabled"] = #encounterJournalList[eName] == 0,
+            ["disabled"] = not ejList or #ejList == 0,
             ["onClick"] = function()
                 LoadExpansion(eName)
             end,

--- a/RaidDebuffs/ExpansionData/LoadExpansionData.xml
+++ b/RaidDebuffs/ExpansionData/LoadExpansionData.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
 	<Script file="ExpansionData.lua"/>
 	<Script file="ExpansionData_deDE.lua"/>
 	<Script file="ExpansionData_frFR.lua"/>

--- a/RaidDebuffs/LoadRaidDebuffs.xml
+++ b/RaidDebuffs/LoadRaidDebuffs.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
 	<Script file="RaidDebuffs_Classic.lua"/>
 	<Script file="RaidDebuffs_TBC.lua"/>
 	<Script file="RaidDebuffs_WotLK.lua"/>

--- a/RaidDebuffs/LoadRaidDebuffs.xml
+++ b/RaidDebuffs/LoadRaidDebuffs.xml
@@ -11,4 +11,5 @@
 	<Script file="RaidDebuffs_SL.lua"/>
 	<Script file="RaidDebuffs_DF.lua"/>
 	<Script file="RaidDebuffs_TWW.lua"/>
+	<Script file="RaidDebuffs_Midnight.lua"/>
 </Ui>

--- a/RaidDebuffs/LoadRaidDebuffs_Cata.xml
+++ b/RaidDebuffs/LoadRaidDebuffs_Cata.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
 	<Script file="RaidDebuffs_Classic.lua"/>
 	<Script file="RaidDebuffs_TBC.lua"/>
 	<Script file="RaidDebuffs_WotLK.lua"/>

--- a/RaidDebuffs/LoadRaidDebuffs_TBC.xml
+++ b/RaidDebuffs/LoadRaidDebuffs_TBC.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
 	<Script file="RaidDebuffs_Classic.lua"/>
     <Script file="RaidDebuffs_TBC.lua"/>
 </Ui>

--- a/RaidDebuffs/LoadRaidDebuffs_Vanilla.xml
+++ b/RaidDebuffs/LoadRaidDebuffs_Vanilla.xml
@@ -1,4 +1,4 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
 	<Script file="RaidDebuffs_Classic.lua"/>
 </Ui>

--- a/RaidDebuffs/LoadRaidDebuffs_Wrath.xml
+++ b/RaidDebuffs/LoadRaidDebuffs_Wrath.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
 	<Script file="RaidDebuffs_Classic.lua"/>
 	<Script file="RaidDebuffs_TBC.lua"/>
 	<Script file="RaidDebuffs_WotLK.lua"/>

--- a/RaidDebuffs/RaidDebuffs_Midnight.lua
+++ b/RaidDebuffs/RaidDebuffs_Midnight.lua
@@ -1,0 +1,697 @@
+---------------------------------------------------------------------
+-- File: RaidDebuffs_Midnight.lua
+-- Author: enderneko (enderneko-dev@outlook.com)
+-- Created : 2026-03-09
+-- Note: Spell IDs extracted from wago.tools DB2 JournalEncounterSection.
+--       Initial version: all encounter spells enabled.
+--       Disable non-debuff spells in-game via the Raid Debuffs config UI.
+---------------------------------------------------------------------
+
+---@class Cell
+local Cell = select(2, ...)
+local F = Cell.funcs
+
+local debuffs = {
+    [1299] = { -- Windrunner Spire
+        ["general"] = {
+        },
+        [2655] = { -- Emberdawn
+            465904, -- Burning Gale
+            466556, -- Flaming Updraft
+            466064, -- Searing Beak
+            469633, -- Flaming Twisters
+            467120, -- Ignited Embers
+            1217762, -- Fire Breath
+        },
+        [2656] = { -- Derelict Duo
+            472736, -- Debilitating Shriek
+            474105, -- Curse of Darkness
+            472724, -- Shadow Bolt
+            472795, -- Heaving Yank
+            474075, -- Heaving Chop
+            472745, -- Splattering Spew
+            472777, -- Gunk Splatter
+            472888, -- Bone Hack
+            1219551, -- Broken Bond
+            1282272, -- Splattered
+            1215813, -- Shadowy
+        },
+        [2657] = { -- Commander Kroluk
+            470963, -- Bladestorm
+            468070, -- Rallying Bellow
+            467620, -- Rampage
+            1217094, -- Throw Axe
+            472043, -- Rallying Bellow
+            472081, -- Reckless Leap
+            1250851, -- Shield Wall
+            1253026, -- Intimidating Shout
+            1251981, -- Chain Lightning
+            467815, -- Intercepting Charge
+            1270620, -- Flame Nova
+            1283357, -- Falling Rubble
+        },
+        [2658] = { -- The Restless Heart
+            1253986, -- Gust Shot
+            468429, -- Bullseye Windblast
+            468442, -- Billowing Wind
+            472556, -- Arrow Rain
+            1253977, -- Turbulent Arrows
+            474528, -- Bolt Gale
+            472662, -- Tempest Slash
+            1216042, -- Squall Leap
+            1282932, -- Storming Soulfont
+        },
+    },
+
+    [1300] = { -- Magisters' Terrace
+        ["general"] = {
+        },
+        [2659] = { -- Arcanotron Custos
+            474345, -- Refueling Protocol
+            474308, -- Energy Orb
+            474496, -- Repulsing Slam
+            1214038, -- Ethereal Shackles
+            1243905, -- Unstable Energy
+            1214081, -- Arcane Expulsion
+            474407, -- Arcane Empowerment
+            1214089, -- Arcane Residue
+        },
+        [2661] = { -- Seranel Sunlash
+            1224903, -- Suppression Zone
+            1225135, -- Feedback
+            1225193, -- Wave of Silence
+            1225792, -- Runic Mark
+            1246446, -- Null Reaction
+            1248689, -- Hastening Ward
+        },
+        [2660] = { -- Gemellus
+            1223847, -- Triplicate
+            1223936, -- Synaptic Nexus
+            1224299, -- Astral Grasp
+            1224401, -- Cosmic Radiation
+            1224100, -- Void Secretions
+            1284958, -- Cosmic Sting
+            1253707, -- Neural Link
+        },
+        [2662] = { -- Degentrius
+            1215087, -- Unstable Void Essence
+            1215161, -- Void Destruction
+            1214714, -- Void Torrent
+            1280113, -- Hulking Fragment
+            1215897, -- Devouring Entropy
+            1271066, -- Entropy Blast
+            1269631, -- Entropy Orb
+            1284627, -- Umbral Splinters
+            1284628, -- Stygian Ichor
+        },
+    },
+
+    [1304] = { -- Murder Row
+        ["general"] = {
+        },
+        [2679] = { -- Kystia Manaheart
+            1230289, -- Illicit Infusion
+            1217989, -- Felshield
+            1223906, -- Fel Nova
+            1230298, -- Chaos Barrage
+            1253811, -- Fel Spray
+            1228198, -- Corroding Spittle
+            1264095, -- Mirror Images
+            1264106, -- Felstorm
+            1230304, -- Light Infusion
+            1265412, -- Destabilized
+        },
+        [2680] = { -- Zaen Bladesorrow
+            474478, -- Killing Spree
+            1218347, -- Murder in a Row
+            474765, -- Same-Day Delivery
+            1201553, -- Fel-Infused Freight
+            1214357, -- Fire Bomb
+            1222795, -- Envenom
+            474515, -- Heartstop Poison
+            1266241, -- Freight Explosion
+        },
+        [2681] = { -- Xathuux the Annihilator
+            1214663, -- Axe Toss
+            474197, -- Demonic Rage
+            474234, -- Burning Steps
+            473898, -- Legion Strike
+            1214650, -- Fel Lightning
+        },
+        [2682] = { -- Lithiel Cinderfury
+            1223204, -- Felfire Burst
+            474375, -- Chaos Bolt
+            1214675, -- Demonic Gateway
+            474457, -- Fingers of Gul'dan
+            1217384, -- Malefic Wave
+            1217415, -- Felshield
+            1226469, -- Malefic Empowerment
+            1231262, -- Felfire Core
+            1216945, -- Searing Fel Flame
+        },
+    },
+
+    [1307] = { -- The Voidspire
+        ["general"] = {
+        },
+        [2733] = { -- Imperator Averzian
+            1251361, -- Shadow's Advance
+            1251583, -- March of the Endless
+            1249262, -- Umbral Collapse
+            1260712, -- Oblivion's Wrath
+            1253918, -- Imperator's Glory
+            1249251, -- Dark Upheaval
+            1249714, -- Umbral Barrier
+            1262036, -- Void Rupture
+            1265540, -- Blackening Wounds
+            1255683, -- Gnashing Void
+            1264164, -- Dark Resilience
+            1267205, -- Hobbled
+            1255702, -- Pitch Bulwark
+            1255749, -- Gathering Darkness
+            1258883, -- Void Fall
+            1274846, -- Dark Barrage
+            1275059, -- Black Miasma
+            1280035, -- Cosmic Shell
+            1280015, -- Void Marked
+            1280075, -- Lingering Darkness
+            1283069, -- Weakened
+            1284786, -- Shadow Phalanx
+        },
+        [2734] = { -- Vorasius
+            1254199, -- Parasite Expulsion
+            1259186, -- Blisterburst
+            1241692, -- Shadowclaw Slam
+            1256855, -- Void Breath
+            1243270, -- Dark Goo
+            1241844, -- Smashed
+            1260052, -- Primordial Roar
+            1244419, -- Overpowering Pulse
+            1273067, -- Aftershock
+            1272937, -- Primordial Power
+            1272527, -- Creep Spit
+            1280101, -- Dark Energy
+        },
+        [2736] = { -- Fallen-King Salhadaar
+            1246175, -- Entropic Unraveling
+            1250686, -- Twisting Obscurity
+            1254081, -- Fractured Projection
+            1247738, -- Void Convergence
+            1254088, -- Shadow Fracture
+            1271577, -- Destabilizing Strikes
+            1260015, -- Umbral Beams
+            1245960, -- Void Infusion
+            1250991, -- Dark Radiation
+            1253032, -- Shattering Twilight
+            1251213, -- Twilight Spikes
+            1245592, -- Torturous Extract
+            1248697, -- Despotic Command
+            1248709, -- Oppressive Darkness
+            1275056, -- Nexus Shield
+            1250828, -- Void Exposure
+        },
+        [2735] = { -- Vaelgor & Ezzorak
+            1244221, -- Dread Breath
+            1262623, -- Nullbeam
+            1244672, -- Nullzone
+            1244917, -- Void Howl
+            1245175, -- Voidbolt
+            1245391, -- Gloom
+            1245420, -- Gloomfield
+            1245554, -- Gloomtouched
+            1249748, -- Midnight Flames
+            1245645, -- Rakfang
+            1248847, -- Radiant Barrier
+            1272867, -- Aura of Light
+            1244413, -- Nullsnap
+            1252157, -- Nullzone Implosion
+            1255763, -- Midnight Manifestation
+            1251686, -- Unbound Shadow
+            1265152, -- Impale
+            1280458, -- Grappling Maw
+            1265131, -- Vaelwing
+            1264467, -- Tail Lash
+            1266570, -- Nullscatter
+            1263623, -- Cosmosis
+            1270189, -- Twilight Bond
+            1270250, -- Twilight Fury
+            1270852, -- Diminish
+            1270513, -- Shadowmark
+        },
+        [2737] = { -- Lightblinded Vanguard
+            1246162, -- Aura of Devotion
+            1251857, -- Judgment
+            1246485, -- Avenger's Shield
+            1248644, -- Divine Toll
+            1248449, -- Aura of Wrath
+            1246736, -- Judgment
+            1246765, -- Divine Storm
+            1246749, -- Sacred Toll
+            1248983, -- Execution Sentence
+            1248451, -- Aura of Peace
+            1246745, -- Exorcism
+            1248674, -- Sacred Shield
+            1248710, -- Tyr's Wrath
+            1251859, -- Shield of the Righteous
+            1251812, -- Final Verdict
+            1246155, -- Consecration
+            1256133, -- Retribution
+            1255738, -- Searing Radiance
+            1258659, -- Light Infused
+            1246391, -- Forbearance
+            1276243, -- Zealous Spirit
+            1272324, -- Divine Tempest
+            1272471, -- Spirit of the Mender
+            1272700, -- Spirit of the Defender
+            1272699, -- Spirit of the Vindictive
+            1276982, -- Divine Consecration
+            1246385, -- Avenging Wrath
+            1246384, -- Divine Shield
+            1258514, -- Blinding Light
+            1249047, -- Divine Hammer
+            1280159, -- Execution Sentence
+            1249130, -- Elekk Charge
+        },
+        [2738] = { -- Crown of the Cosmos
+            1239080, -- Aspect of the End
+            1232470, -- Grasp of Emptiness
+            1233865, -- Null Corona
+            1237251, -- Empowering Darkness
+            1233602, -- Silverstrike Arrow
+            1243982, -- Silverstrike Barrage
+            1234569, -- Stellar Emission
+            1237614, -- Ranger Captain's Mark
+            1237729, -- Silverstrike Ricochet
+            1237038, -- Voidstalker Sting
+            1256787, -- Call of the Void
+            1233470, -- Umbral Tether
+            1232784, -- Bursting Emptiness
+            1261531, -- Corrupting Essence
+            1233689, -- Silver Residue
+            1233778, -- Echoing Darkness
+            1233787, -- Dark Hand
+            1238843, -- Devouring Cosmos
+            1260000, -- Void Barrage
+            1238206, -- Volatile Fissure
+            1238708, -- Dark Rush
+            1239089, -- Gravity Collapse
+            1239279, -- Echoing Darkness
+            1243743, -- Interrupting Tremor
+            1243753, -- Ravenous Abyss
+            1234564, -- Silverstrike Barrage
+            1235622, -- Singularity Eruption
+            1245874, -- Orbiting Matter
+            1246461, -- Rift Slash
+            1246918, -- Cosmic Barrier
+            1255368, -- Void Expulsion
+            1242553, -- Void Remnants
+            1232467, -- Grasp of Emptiness
+            1237837, -- Call of the Void
+            1237844, -- Umbral Tether
+            1238672, -- Coalesced Form
+            1233526, -- Corrupting Essence
+            1255378, -- Bursting Emptiness
+            1261165, -- Empowering Darkness
+        },
+    },
+
+    [1308] = { -- March on Quel'Danas
+        ["general"] = {
+        },
+        [2739] = { -- Belo'ren, Child of Al'ar
+            1242792, -- Incubation of Flames
+            1241313, -- Rebirth
+            1241282, -- Embers of Belo'ren
+            1242260, -- Infused Quills
+            1242981, -- Radiant Echoes
+            1242515, -- Voidlight Convergence
+            1241162, -- Light Feather
+            1241163, -- Void Feather
+            1241292, -- Light Dive
+            1243852, -- Light Eruption
+            1241339, -- Void Dive
+            1243854, -- Void Eruption
+            1242093, -- Light Quill
+            1242094, -- Void Quill
+            1243021, -- Light Echo
+            1243026, -- Void Echo
+            1243866, -- Voidlight Rupture
+            1246709, -- Death Drop
+            1260763, -- Guardian's Edict
+            1261217, -- Light Edict
+            1261218, -- Void Edict
+            1283067, -- Burning Heart
+            1244344, -- Eternal Burns
+            1241640, -- Voidlight Edict
+            1241838, -- Light Patch
+            1241845, -- Void Patch
+            1263412, -- Rebirth
+            1264696, -- Light Blast
+            1264698, -- Void Blast
+            1244348, -- Light Burn
+            1266404, -- Void Burn
+            1262573, -- Ashen Benediction
+            1243320, -- Immortal Flame
+            1242803, -- Light Flames
+            1242815, -- Void Flames
+        },
+        [2740] = { -- Midnight Falls
+            1273158, -- Death's Requiem
+            1249609, -- Dark Rune
+            1249584, -- Dissonance
+            1249796, -- Shattered Sky
+            1284931, -- Termination Prism
+            1284934, -- Terminate
+            1250898, -- The Dark Archangel
+            1251649, -- Disintegration
+            1251789, -- Cosmic Fracture
+            1266388, -- Dark Constellation
+            1252974, -- Dimming
+            1251807, -- Cosmic Fracture
+            1253915, -- Heaven's Glaives
+            1263970, -- Heaven's Lance
+            1282027, -- The Darkwell
+            1254642, -- Thunderous Well
+            1279463, -- Iris of Oblivion
+            1281194, -- Dark Meltdown
+            1284699, -- Light's End
+            1254398, -- Glimmering
+            1254262, -- Tears of L'ura
+            1254256, -- Naaru's Lament
+            1265842, -- Impaled
+            1263253, -- Black Tide
+            1266897, -- Light Siphon
+            1266898, -- Stellar Implosion
+            1249582, -- Resonance
+            1244412, -- Death's Dirge
+            1274455, -- Severance
+            1276529, -- Dimension Breach
+            1276062, -- Dimension Link
+            1260261, -- Total Eclipse
+            1282441, -- Starsplinter
+            1285561, -- Dark Quasar
+            1282034, -- Into the Darkwell
+            1282008, -- Abyssal Pool
+            1282412, -- Core Harvest
+            1266622, -- Midnight
+            1266113, -- Torchbearer
+            1284525, -- Galvanize
+            1282246, -- Void Cores
+            1282249, -- Cosmic Fission
+            1284638, -- Decay
+            1282373, -- Charged Core
+            1282458, -- Radiance
+            1285827, -- Overkill Current
+            1281184, -- Criticality
+            1251386, -- Safeguard Prism
+            1251392, -- Safeguard
+            1284980, -- Grim Symphony
+            1279420, -- Dark Quasar
+            1262055, -- Eclipsed
+            1285685, -- Black Shroud
+            1253104, -- Dawnlight Barrier
+            1287702, -- Severed Surge
+        },
+    },
+
+    [1314] = { -- The Dreamrift
+        ["general"] = {
+        },
+        [2795] = { -- Chimaerus the Undreamt God
+            1262289, -- Alndust Upheaval
+            1245486, -- Corrupted Devastation
+            1245698, -- Alnsight
+            1245406, -- Ravenous Dive
+            1245844, -- Cannibalized Essence
+            1245919, -- Alndust Essence
+            1246132, -- Rift Shroud
+            1272726, -- Rending Tear
+            1249017, -- Fearsome Cry
+            1249207, -- Discordant Roar
+            1250953, -- Rift Sickness
+            1252863, -- Insatiable
+            1246653, -- Caustic Phlegm
+            1257087, -- Consuming Miasma
+            1253744, -- Rift Vulnerability
+            1257093, -- Lingering Miasma
+            1258610, -- Rift Emergence
+            1261997, -- Essence Bolt
+            1262020, -- Colossal Strikes
+            1245727, -- Alnshroud
+            1246621, -- Caustic Phlegm
+            1257085, -- Consuming Miasma
+            1267201, -- Dissonance
+            1264756, -- Rift Madness
+            1245396, -- Consume
+            1282001, -- Alndust Upheaval
+        },
+    },
+
+    [1309] = { -- The Blinding Vale
+        ["general"] = {
+        },
+        [2769] = { -- Lightblossom Trinity
+            1234753, -- Bedrock Slam
+            1234782, -- Fertile Loam
+            1234850, -- Lightsower Dash
+            1235640, -- Thornblade
+            1235564, -- Lightblossom Beam
+            1235751, -- Lightbloom Overgrowth
+            1235814, -- Light-Scorched Earth
+            1235616, -- Light Bolt
+            1235729, -- Light-Gorged
+            1253028, -- Thicket's Trinity
+            1261011, -- Fan Of Thorns
+            1276586, -- Bedrock Surge
+        },
+        [2770] = { -- Ikuzz the Light Hunter
+            1236658, -- Bloodthorn Roots
+            1236746, -- Verdant Stomp
+            1236709, -- Thorncaller Roar
+            1237090, -- Bloodthirsty Gaze
+            1237093, -- Crushing Footfalls
+            1237166, -- Incise
+            1237073, -- Lightcrazed Frenzy
+            1272290, -- Crunched
+        },
+        [2771] = { -- Lightwarden Ruia
+            1239824, -- Lightfire
+            1239830, -- Lightfire Beams
+            1240098, -- Lightfall
+            1239821, -- Warden's Wrath
+            1240210, -- Pulverizing Strikes
+            1241058, -- Grievous Thrash
+            1241067, -- Spirits of the Vale
+            1257094, -- Pulverized
+            1272265, -- Mangling Claws
+        },
+        [2772] = { -- Ziekket
+            1246372, -- Awaken the Lightbloom
+            1247669, -- Lightspore Shot
+            1246379, -- Dormant
+            1246607, -- Concentrated Lightbeam
+            1246660, -- Lightsap
+            1246858, -- Lightbloom's Essence
+            1247039, -- Fluorescent Outburst
+            1247052, -- Lightbloom's Might
+            1247685, -- Thornspike
+            1247377, -- Oozing Xylem
+            1247050, -- Fluorescent Shield
+            1253320, -- Vicious Regrowth
+        },
+    },
+
+    [1311] = { -- Den of Nalorakk
+        ["general"] = {
+        },
+        [2776] = { -- The Hoardmonger
+            1235072, -- Resourceful Measures
+            1235125, -- Hearty Bellow
+            1235129, -- Bonespike Slam
+            1235405, -- Bonespiked
+            1235105, -- Overflowing Supplies
+            1234233, -- Spoiled Supplies
+            1234846, -- Toxic Spores
+            1245593, -- Putrid Burst
+            1234021, -- Earthshatter Slam
+            1234681, -- Ravenous Bellow
+        },
+        [2777] = { -- Sentinel of Winter
+            1235783, -- Shattering Frostspike
+            1235829, -- Winter's Shroud
+            1234314, -- Snowdrift
+            1235656, -- Eternal Winter
+            1235623, -- Raging Squall
+            1235548, -- Glacial Torment
+            1263590, -- Rimeshatter
+            1263597, -- Rime Detonation
+        },
+        [2778] = { -- Nalorakk
+            1243002, -- Fury of the War God
+            1243408, -- Echoing Fury
+            1242860, -- Echoing Maul
+            1255385, -- Forceful Roar
+            1243585, -- Overwhelming Onslaught
+            1262253, -- Demoralizing Scream
+            1243063, -- Concussive Shock
+            1255577, -- Spectral Slash
+            1261776, -- Defensive Stance
+        },
+    },
+
+    [1312] = { -- Midnight
+        ["general"] = {
+        },
+        [2827] = { -- Lu'ashal
+            1276436, -- Dawncrazed Halo
+            1276247, -- Dawnfire Breath
+            1243963, -- Radiant Sunder
+            1243988, -- Blinding Fissure
+            1258427, -- Radiant Flare
+            1258426, -- Radiant Ember
+        },
+        [2829] = { -- Thorm'belan
+            1257825, -- Scintillating Shard
+            1257320, -- Radiant Mote
+            1257737, -- Shard Eruption
+            1258136, -- Rending Claw
+            1257618, -- Dazzling Radiance
+            1258639, -- Shredding Tendrils
+        },
+        [2828] = { -- Predaxas
+            1276193, -- Regurgitation
+            1276320, -- Seismic Slam
+            1276884, -- Voidscatter
+            1277043, -- Bilepool
+            1276988, -- Toxin Splatter
+            1277711, -- Bestial Rage
+            1277694, -- Blood Nova
+            1277829, -- Devour
+        },
+        [2782] = { -- Cragpine
+            1235144, -- War Club
+            1257906, -- Ancient Seeds
+            1235131, -- Rootquake
+            1235134, -- Erupting Roots
+        },
+    },
+
+    [1313] = { -- Voidscar Arena
+        ["general"] = {
+        },
+        [2791] = { -- Taz'Rah
+            1222199, -- Dark Rift
+            1222098, -- Nether Dash
+            1222085, -- Cosmic Spike
+            1225107, -- Ethereal Shards
+            1263593, -- Gather Shadows
+        },
+        [2792] = { -- Atroxus
+            1222724, -- Noxious Breath
+            1222642, -- Hulking Claw
+            1226031, -- Poison Splash
+            1222692, -- Toxic Aura
+            1262497, -- Monstrous Stomp
+            1222484, -- Poison Pool
+            1263971, -- Lingering Poison
+            1222371, -- Provoke Creeper
+            1282892, -- Sickening Bite
+            1283506, -- Fixate
+        },
+        [2793] = { -- Charonus
+            1248130, -- Unstable Singularity
+            1227197, -- Cosmic Blast
+            1222755, -- Void Cascade
+            1223298, -- Gravitic Orbs
+            1263983, -- Condensed Mass
+        },
+    },
+
+    [1315] = { -- Maisara Caverns
+        ["general"] = {
+        },
+        [2810] = { -- Muro'jin and Nekraxx
+            1246666, -- Infected Pinions
+            1249789, -- Revive Pet
+            1243900, -- Fetid Quillstorm
+            1260731, -- Freezing Trap
+            1249479, -- Carrion Swoop
+            1249769, -- Coordinated Assault
+            1249948, -- Bestial Wrath
+            1266480, -- Flanking Spear
+            1260643, -- Barrage
+            1260709, -- Vilebranch Sting
+            1243751, -- Icy Slick
+            1266488, -- Open Wound
+        },
+        [2811] = { -- Vordaza
+            1251554, -- Drain Soul
+            1250708, -- Necrotic Convergence
+            1251204, -- Wrest Phantoms
+            1251775, -- Final Pursuit
+            1251833, -- Soulrot
+            1251813, -- Lingering Dread
+            1252054, -- Unmake
+            1251598, -- Deathshroud
+            1252611, -- Coalesced Death
+            1264974, -- Veiled Presence
+            1264987, -- Withering Miasma
+            1266706, -- Haunting Remains
+        },
+        [2812] = { -- Rak'tul, Vessel of Souls
+            1252676, -- Crush Souls
+            1252777, -- Soulbind
+            1252816, -- Chill of Death
+            1251023, -- Spiritbreaker
+            1248863, -- Deathgorged Vessel
+            1248980, -- Volatile Essence
+            1253788, -- Soulrending Roar
+            1253844, -- Withering Soul
+            1254175, -- Cries of the Fallen
+            1254010, -- Eternal Suffering
+            1255629, -- Spectral Residue
+            1259810, -- Shattered Totem
+            1253909, -- Soul Expulsion
+            1266723, -- Spectral Decay
+        },
+    },
+
+    [1316] = { -- Nexus-Point Xenas
+        ["general"] = {
+        },
+        [2813] = { -- Chief Corewright Kasreth
+            1250553, -- Arcane Zap
+            1251767, -- Reflux Charge
+            1257509, -- Corespark Detonation
+            1264040, -- Flux Collapse
+            1264042, -- Arcane Spill
+            1251579, -- Leyline Array
+            1276485, -- Sparkburn
+        },
+        [2814] = { -- Corewarden Nysarra
+            1247976, -- Lightscar Flare
+            1247937, -- Umbral Lash
+            1249014, -- Eclipsing Step
+            1282723, -- Dusk Frights
+            1282665, -- Void Lash
+            1252828, -- Void Gash
+            1252883, -- Devour the Unworthy
+            1253965, -- Lightscarred
+            1282679, -- Flailstorm
+            1282722, -- Nullify
+            1252703, -- Null Vanguard
+        },
+        [2815] = { -- Lothraxion
+            1253848, -- Brilliant Dispersion
+            1253950, -- Searing Rend
+            1255531, -- Flicker
+            1255389, -- Radiant Scar
+            1266713, -- Mirrored Rend
+            1257613, -- Divine Guile
+            1271511, -- Core Exposure
+        },
+    },
+
+}
+
+F.LoadBuiltInDebuffs(debuffs)

--- a/RaidDebuffs/RaidDebuffs_Midnight_skeleton.lua
+++ b/RaidDebuffs/RaidDebuffs_Midnight_skeleton.lua
@@ -1,0 +1,697 @@
+---------------------------------------------------------------------
+-- File: RaidDebuffs_Midnight.lua
+-- Author: enderneko (enderneko-dev@outlook.com)
+-- Created : 2026-03-09
+-- Note: Spell IDs extracted from wago.tools DB2 JournalEncounterSection.
+--       These are ALL encounter abilities, not just debuffs.
+--       Spells need in-game verification to confirm which are player debuffs.
+---------------------------------------------------------------------
+
+---@class Cell
+local Cell = select(2, ...)
+local F = Cell.funcs
+
+local debuffs = {
+    [1299] = { -- Windrunner Spire
+        ["general"] = {
+        },
+        [2655] = { -- Emberdawn
+            -- 465904, -- Burning Gale
+            -- 466556, -- Flaming Updraft
+            -- 466064, -- Searing Beak
+            -- 469633, -- Flaming Twisters
+            -- 467120, -- Ignited Embers
+            -- 1217762, -- Fire Breath
+        },
+        [2656] = { -- Derelict Duo
+            -- 472736, -- Debilitating Shriek
+            -- 474105, -- Curse of Darkness
+            -- 472724, -- Shadow Bolt
+            -- 472795, -- Heaving Yank
+            -- 474075, -- Heaving Chop
+            -- 472745, -- Splattering Spew
+            -- 472777, -- Gunk Splatter
+            -- 472888, -- Bone Hack
+            -- 1219551, -- Broken Bond
+            -- 1282272, -- Splattered
+            -- 1215813, -- Shadowy
+        },
+        [2657] = { -- Commander Kroluk
+            -- 470963, -- Bladestorm
+            -- 468070, -- Rallying Bellow
+            -- 467620, -- Rampage
+            -- 1217094, -- Throw Axe
+            -- 472043, -- Rallying Bellow
+            -- 472081, -- Reckless Leap
+            -- 1250851, -- Shield Wall
+            -- 1253026, -- Intimidating Shout
+            -- 1251981, -- Chain Lightning
+            -- 467815, -- Intercepting Charge
+            -- 1270620, -- Flame Nova
+            -- 1283357, -- Falling Rubble
+        },
+        [2658] = { -- The Restless Heart
+            -- 1253986, -- Gust Shot
+            -- 468429, -- Bullseye Windblast
+            -- 468442, -- Billowing Wind
+            -- 472556, -- Arrow Rain
+            -- 1253977, -- Turbulent Arrows
+            -- 474528, -- Bolt Gale
+            -- 472662, -- Tempest Slash
+            -- 1216042, -- Squall Leap
+            -- 1282932, -- Storming Soulfont
+        },
+    },
+
+    [1300] = { -- Magisters' Terrace
+        ["general"] = {
+        },
+        [2659] = { -- Arcanotron Custos
+            -- 474345, -- Refueling Protocol
+            -- 474308, -- Energy Orb
+            -- 474496, -- Repulsing Slam
+            -- 1214038, -- Ethereal Shackles
+            -- 1243905, -- Unstable Energy
+            -- 1214081, -- Arcane Expulsion
+            -- 474407, -- Arcane Empowerment
+            -- 1214089, -- Arcane Residue
+        },
+        [2661] = { -- Seranel Sunlash
+            -- 1224903, -- Suppression Zone
+            -- 1225135, -- Feedback
+            -- 1225193, -- Wave of Silence
+            -- 1225792, -- Runic Mark
+            -- 1246446, -- Null Reaction
+            -- 1248689, -- Hastening Ward
+        },
+        [2660] = { -- Gemellus
+            -- 1223847, -- Triplicate
+            -- 1223936, -- Synaptic Nexus
+            -- 1224299, -- Astral Grasp
+            -- 1224401, -- Cosmic Radiation
+            -- 1224100, -- Void Secretions
+            -- 1284958, -- Cosmic Sting
+            -- 1253707, -- Neural Link
+        },
+        [2662] = { -- Degentrius
+            -- 1215087, -- Unstable Void Essence
+            -- 1215161, -- Void Destruction
+            -- 1214714, -- Void Torrent
+            -- 1280113, -- Hulking Fragment
+            -- 1215897, -- Devouring Entropy
+            -- 1271066, -- Entropy Blast
+            -- 1269631, -- Entropy Orb
+            -- 1284627, -- Umbral Splinters
+            -- 1284628, -- Stygian Ichor
+        },
+    },
+
+    [1304] = { -- Murder Row
+        ["general"] = {
+        },
+        [2679] = { -- Kystia Manaheart
+            -- 1230289, -- Illicit Infusion
+            -- 1217989, -- Felshield
+            -- 1223906, -- Fel Nova
+            -- 1230298, -- Chaos Barrage
+            -- 1253811, -- Fel Spray
+            -- 1228198, -- Corroding Spittle
+            -- 1264095, -- Mirror Images
+            -- 1264106, -- Felstorm
+            -- 1230304, -- Light Infusion
+            -- 1265412, -- Destabilized
+        },
+        [2680] = { -- Zaen Bladesorrow
+            -- 474478, -- Killing Spree
+            -- 1218347, -- Murder in a Row
+            -- 474765, -- Same-Day Delivery
+            -- 1201553, -- Fel-Infused Freight
+            -- 1214357, -- Fire Bomb
+            -- 1222795, -- Envenom
+            -- 474515, -- Heartstop Poison
+            -- 1266241, -- Freight Explosion
+        },
+        [2681] = { -- Xathuux the Annihilator
+            -- 1214663, -- Axe Toss
+            -- 474197, -- Demonic Rage
+            -- 474234, -- Burning Steps
+            -- 473898, -- Legion Strike
+            -- 1214650, -- Fel Lightning
+        },
+        [2682] = { -- Lithiel Cinderfury
+            -- 1223204, -- Felfire Burst
+            -- 474375, -- Chaos Bolt
+            -- 1214675, -- Demonic Gateway
+            -- 474457, -- Fingers of Gul'dan
+            -- 1217384, -- Malefic Wave
+            -- 1217415, -- Felshield
+            -- 1226469, -- Malefic Empowerment
+            -- 1231262, -- Felfire Core
+            -- 1216945, -- Searing Fel Flame
+        },
+    },
+
+    [1307] = { -- The Voidspire
+        ["general"] = {
+        },
+        [2733] = { -- Imperator Averzian
+            -- 1251361, -- Shadow's Advance
+            -- 1251583, -- March of the Endless
+            -- 1249262, -- Umbral Collapse
+            -- 1260712, -- Oblivion's Wrath
+            -- 1253918, -- Imperator's Glory
+            -- 1249251, -- Dark Upheaval
+            -- 1249714, -- Umbral Barrier
+            -- 1262036, -- Void Rupture
+            -- 1265540, -- Blackening Wounds
+            -- 1255683, -- Gnashing Void
+            -- 1264164, -- Dark Resilience
+            -- 1267205, -- Hobbled
+            -- 1255702, -- Pitch Bulwark
+            -- 1255749, -- Gathering Darkness
+            -- 1258883, -- Void Fall
+            -- 1274846, -- Dark Barrage
+            -- 1275059, -- Black Miasma
+            -- 1280035, -- Cosmic Shell
+            -- 1280015, -- Void Marked
+            -- 1280075, -- Lingering Darkness
+            -- 1283069, -- Weakened
+            -- 1284786, -- Shadow Phalanx
+        },
+        [2734] = { -- Vorasius
+            -- 1254199, -- Parasite Expulsion
+            -- 1259186, -- Blisterburst
+            -- 1241692, -- Shadowclaw Slam
+            -- 1256855, -- Void Breath
+            -- 1243270, -- Dark Goo
+            -- 1241844, -- Smashed
+            -- 1260052, -- Primordial Roar
+            -- 1244419, -- Overpowering Pulse
+            -- 1273067, -- Aftershock
+            -- 1272937, -- Primordial Power
+            -- 1272527, -- Creep Spit
+            -- 1280101, -- Dark Energy
+        },
+        [2736] = { -- Fallen-King Salhadaar
+            -- 1246175, -- Entropic Unraveling
+            -- 1250686, -- Twisting Obscurity
+            -- 1254081, -- Fractured Projection
+            -- 1247738, -- Void Convergence
+            -- 1254088, -- Shadow Fracture
+            -- 1271577, -- Destabilizing Strikes
+            -- 1260015, -- Umbral Beams
+            -- 1245960, -- Void Infusion
+            -- 1250991, -- Dark Radiation
+            -- 1253032, -- Shattering Twilight
+            -- 1251213, -- Twilight Spikes
+            -- 1245592, -- Torturous Extract
+            -- 1248697, -- Despotic Command
+            -- 1248709, -- Oppressive Darkness
+            -- 1275056, -- Nexus Shield
+            -- 1250828, -- Void Exposure
+        },
+        [2735] = { -- Vaelgor & Ezzorak
+            -- 1244221, -- Dread Breath
+            -- 1262623, -- Nullbeam
+            -- 1244672, -- Nullzone
+            -- 1244917, -- Void Howl
+            -- 1245175, -- Voidbolt
+            -- 1245391, -- Gloom
+            -- 1245420, -- Gloomfield
+            -- 1245554, -- Gloomtouched
+            -- 1249748, -- Midnight Flames
+            -- 1245645, -- Rakfang
+            -- 1248847, -- Radiant Barrier
+            -- 1272867, -- Aura of Light
+            -- 1244413, -- Nullsnap
+            -- 1252157, -- Nullzone Implosion
+            -- 1255763, -- Midnight Manifestation
+            -- 1251686, -- Unbound Shadow
+            -- 1265152, -- Impale
+            -- 1280458, -- Grappling Maw
+            -- 1265131, -- Vaelwing
+            -- 1264467, -- Tail Lash
+            -- 1266570, -- Nullscatter
+            -- 1263623, -- Cosmosis
+            -- 1270189, -- Twilight Bond
+            -- 1270250, -- Twilight Fury
+            -- 1270852, -- Diminish
+            -- 1270513, -- Shadowmark
+        },
+        [2737] = { -- Lightblinded Vanguard
+            -- 1246162, -- Aura of Devotion
+            -- 1251857, -- Judgment
+            -- 1246485, -- Avenger's Shield
+            -- 1248644, -- Divine Toll
+            -- 1248449, -- Aura of Wrath
+            -- 1246736, -- Judgment
+            -- 1246765, -- Divine Storm
+            -- 1246749, -- Sacred Toll
+            -- 1248983, -- Execution Sentence
+            -- 1248451, -- Aura of Peace
+            -- 1246745, -- Exorcism
+            -- 1248674, -- Sacred Shield
+            -- 1248710, -- Tyr's Wrath
+            -- 1251859, -- Shield of the Righteous
+            -- 1251812, -- Final Verdict
+            -- 1246155, -- Consecration
+            -- 1256133, -- Retribution
+            -- 1255738, -- Searing Radiance
+            -- 1258659, -- Light Infused
+            -- 1246391, -- Forbearance
+            -- 1276243, -- Zealous Spirit
+            -- 1272324, -- Divine Tempest
+            -- 1272471, -- Spirit of the Mender
+            -- 1272700, -- Spirit of the Defender
+            -- 1272699, -- Spirit of the Vindictive
+            -- 1276982, -- Divine Consecration
+            -- 1246385, -- Avenging Wrath
+            -- 1246384, -- Divine Shield
+            -- 1258514, -- Blinding Light
+            -- 1249047, -- Divine Hammer
+            -- 1280159, -- Execution Sentence
+            -- 1249130, -- Elekk Charge
+        },
+        [2738] = { -- Crown of the Cosmos
+            -- 1239080, -- Aspect of the End
+            -- 1232470, -- Grasp of Emptiness
+            -- 1233865, -- Null Corona
+            -- 1237251, -- Empowering Darkness
+            -- 1233602, -- Silverstrike Arrow
+            -- 1243982, -- Silverstrike Barrage
+            -- 1234569, -- Stellar Emission
+            -- 1237614, -- Ranger Captain's Mark
+            -- 1237729, -- Silverstrike Ricochet
+            -- 1237038, -- Voidstalker Sting
+            -- 1256787, -- Call of the Void
+            -- 1233470, -- Umbral Tether
+            -- 1232784, -- Bursting Emptiness
+            -- 1261531, -- Corrupting Essence
+            -- 1233689, -- Silver Residue
+            -- 1233778, -- Echoing Darkness
+            -- 1233787, -- Dark Hand
+            -- 1238843, -- Devouring Cosmos
+            -- 1260000, -- Void Barrage
+            -- 1238206, -- Volatile Fissure
+            -- 1238708, -- Dark Rush
+            -- 1239089, -- Gravity Collapse
+            -- 1239279, -- Echoing Darkness
+            -- 1243743, -- Interrupting Tremor
+            -- 1243753, -- Ravenous Abyss
+            -- 1234564, -- Silverstrike Barrage
+            -- 1235622, -- Singularity Eruption
+            -- 1245874, -- Orbiting Matter
+            -- 1246461, -- Rift Slash
+            -- 1246918, -- Cosmic Barrier
+            -- 1255368, -- Void Expulsion
+            -- 1242553, -- Void Remnants
+            -- 1232467, -- Grasp of Emptiness
+            -- 1237837, -- Call of the Void
+            -- 1237844, -- Umbral Tether
+            -- 1238672, -- Coalesced Form
+            -- 1233526, -- Corrupting Essence
+            -- 1255378, -- Bursting Emptiness
+            -- 1261165, -- Empowering Darkness
+        },
+    },
+
+    [1308] = { -- March on Quel'Danas
+        ["general"] = {
+        },
+        [2739] = { -- Belo'ren, Child of Al'ar
+            -- 1242792, -- Incubation of Flames
+            -- 1241313, -- Rebirth
+            -- 1241282, -- Embers of Belo'ren
+            -- 1242260, -- Infused Quills
+            -- 1242981, -- Radiant Echoes
+            -- 1242515, -- Voidlight Convergence
+            -- 1241162, -- Light Feather
+            -- 1241163, -- Void Feather
+            -- 1241292, -- Light Dive
+            -- 1243852, -- Light Eruption
+            -- 1241339, -- Void Dive
+            -- 1243854, -- Void Eruption
+            -- 1242093, -- Light Quill
+            -- 1242094, -- Void Quill
+            -- 1243021, -- Light Echo
+            -- 1243026, -- Void Echo
+            -- 1243866, -- Voidlight Rupture
+            -- 1246709, -- Death Drop
+            -- 1260763, -- Guardian's Edict
+            -- 1261217, -- Light Edict
+            -- 1261218, -- Void Edict
+            -- 1283067, -- Burning Heart
+            -- 1244344, -- Eternal Burns
+            -- 1241640, -- Voidlight Edict
+            -- 1241838, -- Light Patch
+            -- 1241845, -- Void Patch
+            -- 1263412, -- Rebirth
+            -- 1264696, -- Light Blast
+            -- 1264698, -- Void Blast
+            -- 1244348, -- Light Burn
+            -- 1266404, -- Void Burn
+            -- 1262573, -- Ashen Benediction
+            -- 1243320, -- Immortal Flame
+            -- 1242803, -- Light Flames
+            -- 1242815, -- Void Flames
+        },
+        [2740] = { -- Midnight Falls
+            -- 1273158, -- Death's Requiem
+            -- 1249609, -- Dark Rune
+            -- 1249584, -- Dissonance
+            -- 1249796, -- Shattered Sky
+            -- 1284931, -- Termination Prism
+            -- 1284934, -- Terminate
+            -- 1250898, -- The Dark Archangel
+            -- 1251649, -- Disintegration
+            -- 1251789, -- Cosmic Fracture
+            -- 1266388, -- Dark Constellation
+            -- 1252974, -- Dimming
+            -- 1251807, -- Cosmic Fracture
+            -- 1253915, -- Heaven's Glaives
+            -- 1263970, -- Heaven's Lance
+            -- 1282027, -- The Darkwell
+            -- 1254642, -- Thunderous Well
+            -- 1279463, -- Iris of Oblivion
+            -- 1281194, -- Dark Meltdown
+            -- 1284699, -- Light's End
+            -- 1254398, -- Glimmering
+            -- 1254262, -- Tears of L'ura
+            -- 1254256, -- Naaru's Lament
+            -- 1265842, -- Impaled
+            -- 1263253, -- Black Tide
+            -- 1266897, -- Light Siphon
+            -- 1266898, -- Stellar Implosion
+            -- 1249582, -- Resonance
+            -- 1244412, -- Death's Dirge
+            -- 1274455, -- Severance
+            -- 1276529, -- Dimension Breach
+            -- 1276062, -- Dimension Link
+            -- 1260261, -- Total Eclipse
+            -- 1282441, -- Starsplinter
+            -- 1285561, -- Dark Quasar
+            -- 1282034, -- Into the Darkwell
+            -- 1282008, -- Abyssal Pool
+            -- 1282412, -- Core Harvest
+            -- 1266622, -- Midnight
+            -- 1266113, -- Torchbearer
+            -- 1284525, -- Galvanize
+            -- 1282246, -- Void Cores
+            -- 1282249, -- Cosmic Fission
+            -- 1284638, -- Decay
+            -- 1282373, -- Charged Core
+            -- 1282458, -- Radiance
+            -- 1285827, -- Overkill Current
+            -- 1281184, -- Criticality
+            -- 1251386, -- Safeguard Prism
+            -- 1251392, -- Safeguard
+            -- 1284980, -- Grim Symphony
+            -- 1279420, -- Dark Quasar
+            -- 1262055, -- Eclipsed
+            -- 1285685, -- Black Shroud
+            -- 1253104, -- Dawnlight Barrier
+            -- 1287702, -- Severed Surge
+        },
+    },
+
+    [1314] = { -- The Dreamrift
+        ["general"] = {
+        },
+        [2795] = { -- Chimaerus the Undreamt God
+            -- 1262289, -- Alndust Upheaval
+            -- 1245486, -- Corrupted Devastation
+            -- 1245698, -- Alnsight
+            -- 1245406, -- Ravenous Dive
+            -- 1245844, -- Cannibalized Essence
+            -- 1245919, -- Alndust Essence
+            -- 1246132, -- Rift Shroud
+            -- 1272726, -- Rending Tear
+            -- 1249017, -- Fearsome Cry
+            -- 1249207, -- Discordant Roar
+            -- 1250953, -- Rift Sickness
+            -- 1252863, -- Insatiable
+            -- 1246653, -- Caustic Phlegm
+            -- 1257087, -- Consuming Miasma
+            -- 1253744, -- Rift Vulnerability
+            -- 1257093, -- Lingering Miasma
+            -- 1258610, -- Rift Emergence
+            -- 1261997, -- Essence Bolt
+            -- 1262020, -- Colossal Strikes
+            -- 1245727, -- Alnshroud
+            -- 1246621, -- Caustic Phlegm
+            -- 1257085, -- Consuming Miasma
+            -- 1267201, -- Dissonance
+            -- 1264756, -- Rift Madness
+            -- 1245396, -- Consume
+            -- 1282001, -- Alndust Upheaval
+        },
+    },
+
+    [1309] = { -- The Blinding Vale
+        ["general"] = {
+        },
+        [2769] = { -- Lightblossom Trinity
+            -- 1234753, -- Bedrock Slam
+            -- 1234782, -- Fertile Loam
+            -- 1234850, -- Lightsower Dash
+            -- 1235640, -- Thornblade
+            -- 1235564, -- Lightblossom Beam
+            -- 1235751, -- Lightbloom Overgrowth
+            -- 1235814, -- Light-Scorched Earth
+            -- 1235616, -- Light Bolt
+            -- 1235729, -- Light-Gorged
+            -- 1253028, -- Thicket's Trinity
+            -- 1261011, -- Fan Of Thorns
+            -- 1276586, -- Bedrock Surge
+        },
+        [2770] = { -- Ikuzz the Light Hunter
+            -- 1236658, -- Bloodthorn Roots
+            -- 1236746, -- Verdant Stomp
+            -- 1236709, -- Thorncaller Roar
+            -- 1237090, -- Bloodthirsty Gaze
+            -- 1237093, -- Crushing Footfalls
+            -- 1237166, -- Incise
+            -- 1237073, -- Lightcrazed Frenzy
+            -- 1272290, -- Crunched
+        },
+        [2771] = { -- Lightwarden Ruia
+            -- 1239824, -- Lightfire
+            -- 1239830, -- Lightfire Beams
+            -- 1240098, -- Lightfall
+            -- 1239821, -- Warden's Wrath
+            -- 1240210, -- Pulverizing Strikes
+            -- 1241058, -- Grievous Thrash
+            -- 1241067, -- Spirits of the Vale
+            -- 1257094, -- Pulverized
+            -- 1272265, -- Mangling Claws
+        },
+        [2772] = { -- Ziekket
+            -- 1246372, -- Awaken the Lightbloom
+            -- 1247669, -- Lightspore Shot
+            -- 1246379, -- Dormant
+            -- 1246607, -- Concentrated Lightbeam
+            -- 1246660, -- Lightsap
+            -- 1246858, -- Lightbloom's Essence
+            -- 1247039, -- Fluorescent Outburst
+            -- 1247052, -- Lightbloom's Might
+            -- 1247685, -- Thornspike
+            -- 1247377, -- Oozing Xylem
+            -- 1247050, -- Fluorescent Shield
+            -- 1253320, -- Vicious Regrowth
+        },
+    },
+
+    [1311] = { -- Den of Nalorakk
+        ["general"] = {
+        },
+        [2776] = { -- The Hoardmonger
+            -- 1235072, -- Resourceful Measures
+            -- 1235125, -- Hearty Bellow
+            -- 1235129, -- Bonespike Slam
+            -- 1235405, -- Bonespiked
+            -- 1235105, -- Overflowing Supplies
+            -- 1234233, -- Spoiled Supplies
+            -- 1234846, -- Toxic Spores
+            -- 1245593, -- Putrid Burst
+            -- 1234021, -- Earthshatter Slam
+            -- 1234681, -- Ravenous Bellow
+        },
+        [2777] = { -- Sentinel of Winter
+            -- 1235783, -- Shattering Frostspike
+            -- 1235829, -- Winter's Shroud
+            -- 1234314, -- Snowdrift
+            -- 1235656, -- Eternal Winter
+            -- 1235623, -- Raging Squall
+            -- 1235548, -- Glacial Torment
+            -- 1263590, -- Rimeshatter
+            -- 1263597, -- Rime Detonation
+        },
+        [2778] = { -- Nalorakk
+            -- 1243002, -- Fury of the War God
+            -- 1243408, -- Echoing Fury
+            -- 1242860, -- Echoing Maul
+            -- 1255385, -- Forceful Roar
+            -- 1243585, -- Overwhelming Onslaught
+            -- 1262253, -- Demoralizing Scream
+            -- 1243063, -- Concussive Shock
+            -- 1255577, -- Spectral Slash
+            -- 1261776, -- Defensive Stance
+        },
+    },
+
+    [1312] = { -- Midnight
+        ["general"] = {
+        },
+        [2827] = { -- Lu'ashal
+            -- 1276436, -- Dawncrazed Halo
+            -- 1276247, -- Dawnfire Breath
+            -- 1243963, -- Radiant Sunder
+            -- 1243988, -- Blinding Fissure
+            -- 1258427, -- Radiant Flare
+            -- 1258426, -- Radiant Ember
+        },
+        [2829] = { -- Thorm'belan
+            -- 1257825, -- Scintillating Shard
+            -- 1257320, -- Radiant Mote
+            -- 1257737, -- Shard Eruption
+            -- 1258136, -- Rending Claw
+            -- 1257618, -- Dazzling Radiance
+            -- 1258639, -- Shredding Tendrils
+        },
+        [2828] = { -- Predaxas
+            -- 1276193, -- Regurgitation
+            -- 1276320, -- Seismic Slam
+            -- 1276884, -- Voidscatter
+            -- 1277043, -- Bilepool
+            -- 1276988, -- Toxin Splatter
+            -- 1277711, -- Bestial Rage
+            -- 1277694, -- Blood Nova
+            -- 1277829, -- Devour
+        },
+        [2782] = { -- Cragpine
+            -- 1235144, -- War Club
+            -- 1257906, -- Ancient Seeds
+            -- 1235131, -- Rootquake
+            -- 1235134, -- Erupting Roots
+        },
+    },
+
+    [1313] = { -- Voidscar Arena
+        ["general"] = {
+        },
+        [2791] = { -- Taz'Rah
+            -- 1222199, -- Dark Rift
+            -- 1222098, -- Nether Dash
+            -- 1222085, -- Cosmic Spike
+            -- 1225107, -- Ethereal Shards
+            -- 1263593, -- Gather Shadows
+        },
+        [2792] = { -- Atroxus
+            -- 1222724, -- Noxious Breath
+            -- 1222642, -- Hulking Claw
+            -- 1226031, -- Poison Splash
+            -- 1222692, -- Toxic Aura
+            -- 1262497, -- Monstrous Stomp
+            -- 1222484, -- Poison Pool
+            -- 1263971, -- Lingering Poison
+            -- 1222371, -- Provoke Creeper
+            -- 1282892, -- Sickening Bite
+            -- 1283506, -- Fixate
+        },
+        [2793] = { -- Charonus
+            -- 1248130, -- Unstable Singularity
+            -- 1227197, -- Cosmic Blast
+            -- 1222755, -- Void Cascade
+            -- 1223298, -- Gravitic Orbs
+            -- 1263983, -- Condensed Mass
+        },
+    },
+
+    [1315] = { -- Maisara Caverns
+        ["general"] = {
+        },
+        [2810] = { -- Muro'jin and Nekraxx
+            -- 1246666, -- Infected Pinions
+            -- 1249789, -- Revive Pet
+            -- 1243900, -- Fetid Quillstorm
+            -- 1260731, -- Freezing Trap
+            -- 1249479, -- Carrion Swoop
+            -- 1249769, -- Coordinated Assault
+            -- 1249948, -- Bestial Wrath
+            -- 1266480, -- Flanking Spear
+            -- 1260643, -- Barrage
+            -- 1260709, -- Vilebranch Sting
+            -- 1243751, -- Icy Slick
+            -- 1266488, -- Open Wound
+        },
+        [2811] = { -- Vordaza
+            -- 1251554, -- Drain Soul
+            -- 1250708, -- Necrotic Convergence
+            -- 1251204, -- Wrest Phantoms
+            -- 1251775, -- Final Pursuit
+            -- 1251833, -- Soulrot
+            -- 1251813, -- Lingering Dread
+            -- 1252054, -- Unmake
+            -- 1251598, -- Deathshroud
+            -- 1252611, -- Coalesced Death
+            -- 1264974, -- Veiled Presence
+            -- 1264987, -- Withering Miasma
+            -- 1266706, -- Haunting Remains
+        },
+        [2812] = { -- Rak'tul, Vessel of Souls
+            -- 1252676, -- Crush Souls
+            -- 1252777, -- Soulbind
+            -- 1252816, -- Chill of Death
+            -- 1251023, -- Spiritbreaker
+            -- 1248863, -- Deathgorged Vessel
+            -- 1248980, -- Volatile Essence
+            -- 1253788, -- Soulrending Roar
+            -- 1253844, -- Withering Soul
+            -- 1254175, -- Cries of the Fallen
+            -- 1254010, -- Eternal Suffering
+            -- 1255629, -- Spectral Residue
+            -- 1259810, -- Shattered Totem
+            -- 1253909, -- Soul Expulsion
+            -- 1266723, -- Spectral Decay
+        },
+    },
+
+    [1316] = { -- Nexus-Point Xenas
+        ["general"] = {
+        },
+        [2813] = { -- Chief Corewright Kasreth
+            -- 1250553, -- Arcane Zap
+            -- 1251767, -- Reflux Charge
+            -- 1257509, -- Corespark Detonation
+            -- 1264040, -- Flux Collapse
+            -- 1264042, -- Arcane Spill
+            -- 1251579, -- Leyline Array
+            -- 1276485, -- Sparkburn
+        },
+        [2814] = { -- Corewarden Nysarra
+            -- 1247976, -- Lightscar Flare
+            -- 1247937, -- Umbral Lash
+            -- 1249014, -- Eclipsing Step
+            -- 1282723, -- Dusk Frights
+            -- 1282665, -- Void Lash
+            -- 1252828, -- Void Gash
+            -- 1252883, -- Devour the Unworthy
+            -- 1253965, -- Lightscarred
+            -- 1282679, -- Flailstorm
+            -- 1282722, -- Nullify
+            -- 1252703, -- Null Vanguard
+        },
+        [2815] = { -- Lothraxion
+            -- 1253848, -- Brilliant Dispersion
+            -- 1253950, -- Searing Rend
+            -- 1255531, -- Flicker
+            -- 1255389, -- Radiant Scar
+            -- 1266713, -- Mirrored Rend
+            -- 1257613, -- Divine Guile
+            -- 1271511, -- Core Exposure
+        },
+    },
+
+}
+
+F.LoadBuiltInDebuffs(debuffs)

--- a/RaidFrames/Groups/NPCFrame.lua
+++ b/RaidFrames/Groups/NPCFrame.lua
@@ -195,22 +195,47 @@ end
 -------------------------------------------------
 -- FIXME: fix health updating boss678
 -- ! BLIZZARD, FIX IT!
+-- NOTE: On Midnight (12.0.0+) COMBAT_LOG_EVENT_UNFILTERED is unavailable.
+-- Boss6-8 health/aura updates fall back entirely to the periodic poll
+-- (elapsed3 >= 5) and UNIT_HEALTH / UNIT_AURA unit events registered below.
+-- The CLEU path is guarded by Cell.isMidnight.
 -------------------------------------------------
 local boss678_guidToButton = {}
 local boss678_buttonToGuid = {}
 
 local cleu = CreateFrame("Frame")
-cleu:SetScript("OnEvent", function()
-    local timestamp, subEvent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo()
-    if boss678_guidToButton[destGUID] then
-        if subEvent == "SPELL_HEAL" or subEvent == "SPELL_PERIODIC_HEAL" or subEvent == "SPELL_DAMAGE" or subEvent == "SPELL_PERIODIC_DAMAGE" then
-            -- print("UpdateHealth:", boss678_guidToButton[destGUID]:GetName())
-            B.UpdateHealth(boss678_guidToButton[destGUID])
-        elseif subEvent == "SPELL_AURA_REFRESH" or subEvent == "SPELL_AURA_APPLIED" or subEvent == "SPELL_AURA_REMOVED" or subEvent == "SPELL_AURA_APPLIED_DOSE" or subEvent == "SPELL_AURA_REMOVED_DOSE" then
-            B.UpdateAuras(boss678_guidToButton[destGUID])
+
+if not Cell.isMidnight then
+    cleu:SetScript("OnEvent", function()
+        local timestamp, subEvent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo()
+        if boss678_guidToButton[destGUID] then
+            if subEvent == "SPELL_HEAL" or subEvent == "SPELL_PERIODIC_HEAL" or subEvent == "SPELL_DAMAGE" or subEvent == "SPELL_PERIODIC_DAMAGE" then
+                B.UpdateHealth(boss678_guidToButton[destGUID])
+            elseif subEvent == "SPELL_AURA_REFRESH" or subEvent == "SPELL_AURA_APPLIED" or subEvent == "SPELL_AURA_REMOVED" or subEvent == "SPELL_AURA_APPLIED_DOSE" or subEvent == "SPELL_AURA_REMOVED_DOSE" then
+                B.UpdateAuras(boss678_guidToButton[destGUID])
+            end
         end
-    end
-end)
+    end)
+else
+    -- Midnight: use UNIT_HEALTH and UNIT_AURA for boss6-8 unit events.
+    -- These events fire for units that WoW tracks; boss6-8 visibility may be
+    -- limited but is better than nothing and complements the periodic poll.
+    cleu:SetScript("OnEvent", function(self, event, unit)
+        local button = unit and F.HandleUnitButton and nil
+        -- resolve unit to button via the boss678 unit map
+        for idx = 6, 8 do
+            local b = Cell.unitButtons.npc[idx]
+            if b and b.states and b.states.unit == unit then
+                if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
+                    B.UpdateHealth(b)
+                elseif event == "UNIT_AURA" then
+                    B.UpdateAuras(b)
+                end
+                break
+            end
+        end
+    end)
+end
 
 for i = 6, 8 do
     local button = Cell.unitButtons.npc[i]
@@ -223,6 +248,16 @@ for i = 6, 8 do
 
         -- update now
         B.UpdateAll(button)
+
+        if Cell.isMidnight then
+            -- Register unit events for this boss slot on Midnight
+            local unit = button.states.unit
+            if unit then
+                cleu:RegisterUnitEvent("UNIT_HEALTH", unit)
+                cleu:RegisterUnitEvent("UNIT_MAXHEALTH", unit)
+                cleu:RegisterUnitEvent("UNIT_AURA", unit)
+            end
+        end
     end)
 
     button.helper:HookScript("OnHide", function()
@@ -233,9 +268,13 @@ for i = 6, 8 do
         button.helper.elapsed2 = nil
         button.helper.elapsed3 = nil
 
-        if F.Getn(boss678_buttonToGuid) == 0 then
-            cleu:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        if not Cell.isMidnight then
+            if F.Getn(boss678_buttonToGuid) == 0 then
+                cleu:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+            end
         end
+        -- Note: unit events registered via RegisterUnitEvent are automatically
+        -- unregistered when no units match; no explicit cleanup needed.
     end)
 
     button.helper:HookScript("OnUpdate", function(self, elapsed)
@@ -258,11 +297,13 @@ for i = 6, 8 do
             button.helper.elapsed = 0
         end
 
-        if button.helper.elapsed2 >= 1 then
-            if not cleu:IsEventRegistered("COMBAT_LOG_EVENT_UNFILTERED") then
-                cleu:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        if not Cell.isMidnight then
+            if button.helper.elapsed2 >= 1 then
+                if not cleu:IsEventRegistered("COMBAT_LOG_EVENT_UNFILTERED") then
+                    cleu:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+                end
+                button.helper.elapsed2 = 0
             end
-            button.helper.elapsed2 = 0
         end
 
         if button.helper.elapsed3 >= 5 then

--- a/RaidFrames/MainFrame.lua
+++ b/RaidFrames/MainFrame.lua
@@ -90,7 +90,11 @@ options:SetScript("OnClick", function(self, button)
 end)
 options:HookScript("OnEnter", function()
     CellTooltip:SetOwner(options, "ANCHOR_NONE")
-    CellTooltip:SetPoint(tooltipPoint, options, tooltipRelativePoint, tooltipX, tooltipY)
+    if tooltipPoint then
+        CellTooltip:SetPoint(tooltipPoint, options, tooltipRelativePoint, tooltipX, tooltipY)
+    else
+        CellTooltip:SetPoint("TOPLEFT", options, "BOTTOMLEFT", 0, -3)
+    end
     CellTooltip:AddLine(L["Options"])
     CellTooltip:AddLine("|cffffb5c5"..L["Right-Click"]..": |cffffffff"..L["refresh unit buttons"])
     CellTooltip:Show()
@@ -262,6 +266,7 @@ hoverFrame:SetScript("OnLeave", function()
 end)
 
 local function UpdateHoverFrame()
+    if not Cell.vars.currentLayoutTable then return end
     local anchor = Cell.vars.currentLayoutTable["main"]["anchor"]
     local top, bottom, left, right
 
@@ -352,7 +357,11 @@ end
 
 raid:HookScript("OnEnter", function()
     CellTooltip:SetOwner(raid, "ANCHOR_NONE")
-    CellTooltip:SetPoint(tooltipPoint, raid, tooltipRelativePoint, tooltipX, tooltipY)
+    if tooltipPoint then
+        CellTooltip:SetPoint(tooltipPoint, raid, tooltipRelativePoint, tooltipX, tooltipY)
+    else
+        CellTooltip:SetPoint("TOPLEFT", raid, "BOTTOMLEFT", 0, -3)
+    end
     UpdateRaidSetupTooltip()
 end)
 
@@ -399,6 +408,7 @@ Cell.RegisterCallback("GroupTypeChanged", "MainFrame_GroupTypeChanged", MainFram
 -- load & update
 -------------------------------------------------
 local function UpdatePosition()
+    if not Cell.vars.currentLayoutTable then return end
     local anchor = Cell.vars.currentLayoutTable["main"]["anchor"]
 
     cellMainFrame:ClearAllPoints()

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -60,11 +60,12 @@ local UnitPhaseReason = UnitPhaseReason
 -- local UnitDebuff = UnitDebuff
 local IsInRaid = IsInRaid
 local UnitDetailedThreatSituation = UnitDetailedThreatSituation
-local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
 local GetAuraDataByAuraInstanceID = C_UnitAuras.GetAuraDataByAuraInstanceID
 local GetAuraSlots = C_UnitAuras.GetAuraSlots
 local GetAuraDataBySlot = C_UnitAuras.GetAuraDataBySlot
 local IsDelveInProgress = C_PartyInfo.IsDelveInProgress
+local UnitGetDetailedHealPrediction = UnitGetDetailedHealPrediction  -- nil pre-12.0
+local CreateUnitHealPredictionCalculator = CreateUnitHealPredictionCalculator  -- nil pre-12.0
 
 --! for AI followers, UnitClassBase is buggy
 local UnitClassBase = function(unit)
@@ -75,7 +76,38 @@ local barAnimationType, highlightEnabled, predictionEnabled
 local shieldEnabled, overshieldEnabled, overshieldReverseFillEnabled
 local absorbEnabled, absorbInvertColor
 
-local CheckCLEURequired
+-- Midnight: Curve for CELL_FADE_OUT_HEALTH_PERCENT feature
+-- Maps health percent → alpha so we can evaluate secret health% without comparisons
+local fadeOutHealthCurve
+local fadeOutHealthCurve_threshold -- track last threshold to know when to rebuild
+local fadeOutHealthCurve_alpha -- track last outOfRangeAlpha to know when to rebuild
+
+-- Builds/rebuilds the fade-out health curve when threshold or alpha changes.
+-- health% < threshold → alpha 1.0 (fully visible, needs healing)
+-- health% >= threshold → outOfRangeAlpha (faded out, healthy enough)
+local function RebuildFadeOutHealthCurve()
+    if not Cell.isMidnight or not C_CurveUtil then return end
+    local threshold = CELL_FADE_OUT_HEALTH_PERCENT
+    local alpha = CellDB and CellDB["appearance"] and CellDB["appearance"]["outOfRangeAlpha"] or 0.4
+    if not threshold then
+        fadeOutHealthCurve = nil
+        fadeOutHealthCurve_threshold = nil
+        fadeOutHealthCurve_alpha = nil
+        return
+    end
+    if fadeOutHealthCurve and fadeOutHealthCurve_threshold == threshold and fadeOutHealthCurve_alpha == alpha then
+        return -- no change needed
+    end
+    fadeOutHealthCurve = C_CurveUtil.CreateCurve()
+    -- Below threshold: fully visible (unit needs healing)
+    fadeOutHealthCurve:AddPoint(0.0, 1.0)
+    fadeOutHealthCurve:AddPoint(threshold - 0.001, 1.0)
+    -- At/above threshold: faded out (unit is healthy enough)
+    fadeOutHealthCurve:AddPoint(threshold, alpha)
+    fadeOutHealthCurve:AddPoint(1.0, alpha)
+    fadeOutHealthCurve_threshold = threshold
+    fadeOutHealthCurve_alpha = alpha
+end
 
 -------------------------------------------------
 -- unit button func declarations
@@ -115,8 +147,6 @@ end
 local function ResetIndicators()
     wipe(enabledIndicators)
     wipe(indicatorNums)
-
-    CheckCLEURequired()
 
     for _, t in next, Cell.vars.currentLayoutTable["indicators"] do
         -- update enabled
@@ -1080,11 +1110,23 @@ end
 -------------------------------------------------
 local function UpdateAuraRefreshState(auraInfo)
     if Cell.vars.iconAnimation == "duration" then
-        local timeIncreased = auraInfo.oldExpirationTime and ((auraInfo.expirationTime or 0) - auraInfo.oldExpirationTime >= 0.5) or false
-        local countIncreased = auraInfo.oldApplications and (auraInfo.applications > auraInfo.oldApplications) or false
+        local timeIncreased, countIncreased
+        if Cell.isMidnight then
+            -- Can't do arithmetic/comparison on secret expirationTime or applications (Midnight 12.0.0+)
+            timeIncreased = false
+            countIncreased = false
+        else
+            timeIncreased = auraInfo.oldExpirationTime and ((auraInfo.expirationTime or 0) - auraInfo.oldExpirationTime >= 0.5) or false
+            countIncreased = auraInfo.oldApplications and (auraInfo.applications > auraInfo.oldApplications) or false
+        end
         auraInfo.refreshing = timeIncreased or countIncreased
     elseif Cell.vars.iconAnimation == "stack" then
-        auraInfo.refreshing = auraInfo.oldApplications and (auraInfo.applications > auraInfo.oldApplications) or false
+        if Cell.isMidnight then
+            -- Can't compare secret applications value (Midnight 12.0.0+)
+            auraInfo.refreshing = false
+        else
+            auraInfo.refreshing = auraInfo.oldApplications and (auraInfo.applications > auraInfo.oldApplications) or false
+        end
     else
         auraInfo.refreshing = false
     end
@@ -1118,6 +1160,8 @@ end
 local function HandleDebuff(self, auraInfo)
     local auraInstanceID = auraInfo.auraInstanceID
     local name = auraInfo.name
+    -- auraInfo.icon may be a secret fileID on Midnight 12.0.0+
+    -- SetTexture() accepts secret numbers, so this works as-is
     local icon = auraInfo.icon
     local count = auraInfo.applications
     local debuffType = auraInfo.dispelName or ""
@@ -1131,16 +1175,28 @@ local function HandleDebuff(self, auraInfo)
     auraInfo.refreshing = false
 
     -- check Bleed
+    -- On Midnight in restricted context, spellId may be secret; I.CheckDebuffType guards internally
     debuffType = I.CheckDebuffType(debuffType, spellId)
 
     if duration then
         UpdateAuraRefreshState(auraInfo)
         self._debuffs_cache[auraInstanceID] = auraInfo
 
-        if enabledIndicators["debuffs"] and not Cell.vars.debuffBlacklist[spellId] then
+        -- On Midnight in restricted context, spellId may be secret — can't use as table key
+        -- Use F.IsAuraRestricted() to choose code path at runtime
+        local isBig = false
+        local isBlacklisted = false
+        local isDispelBlacklisted = false
+        if not Cell.isMidnight or not F.IsAuraRestricted() then
+            isBig = spellId and Cell.vars.bigDebuffs[spellId] or false
+            isBlacklisted = spellId and Cell.vars.debuffBlacklist[spellId] or false
+            isDispelBlacklisted = spellId and Cell.vars.dispelBlacklist[spellId] or false
+        end
+
+        if enabledIndicators["debuffs"] and not isBlacklisted then
             -- all debuffs / only dispellableByMe
             if not indicatorBooleans["debuffs"] or I.CanDispel(debuffType) then
-                if Cell.vars.bigDebuffs[spellId] then
+                if isBig then
                     self._debuffs_big[auraInstanceID] = true
                 else
                     self._debuffs_normal[auraInstanceID] = true
@@ -1171,7 +1227,7 @@ local function HandleDebuff(self, auraInfo)
             -- all dispels / only dispellableByMe
             if not indicatorBooleans ["dispels"]["dispellableByMe"] or I.CanDispel(debuffType) then
                 if indicatorBooleans["dispels"][debuffType] then
-                    if Cell.vars.dispelBlacklist[spellId] then
+                    if isDispelBlacklisted then
                         -- no highlight
                         self._debuffs_dispel[debuffType] = false
                     else
@@ -1190,22 +1246,25 @@ local function HandleDebuff(self, auraInfo)
             self._debuffs_normal[auraInstanceID] = nil
         end
 
-        -- resurrections: 图腾复生/复生
-        if spellId == 255234 or spellId == 225080 then
-            -- NOTE: this rez lasts longer than the debuff
-            self._debuffs.resurrectionFound = true
-            self.states.hasRezDebuff = true
-        end
+        -- On Midnight in restricted context, spellId may be secret — can't use in equality comparisons
+        if not Cell.isMidnight or not F.IsAuraRestricted() then
+            -- resurrections: 图腾复生/复生
+            if spellId == 255234 or spellId == 225080 then
+                -- NOTE: this rez lasts longer than the debuff
+                self._debuffs.resurrectionFound = true
+                self.states.hasRezDebuff = true
+            end
 
-        -- BG orbs
-        if spellId == 121164 then
-            self.states.BGOrb = "blue"
-        elseif spellId == 121175 then
-            self.states.BGOrb = "purple"
-        elseif spellId == 121176 then
-            self.states.BGOrb = "green"
-        elseif spellId == 121177 then
-            self.states.BGOrb = "orange"
+            -- BG orbs
+            if spellId == 121164 then
+                self.states.BGOrb = "blue"
+            elseif spellId == 121175 then
+                self.states.BGOrb = "purple"
+            elseif spellId == 121176 then
+                self.states.BGOrb = "green"
+            elseif spellId == 121177 then
+                self.states.BGOrb = "orange"
+            end
         end
     end
 end
@@ -1389,6 +1448,8 @@ local function HandleBuff(self, auraInfo)
 
     local auraInstanceID = auraInfo.auraInstanceID
     local name = auraInfo.name
+    -- auraInfo.icon may be a secret fileID on Midnight 12.0.0+
+    -- SetTexture() accepts secret numbers, so this works as-is
     local icon = auraInfo.icon
     local count = auraInfo.applications
     -- local debuffType = auraInfo.isHarmful and auraInfo.dispelName
@@ -1444,11 +1505,14 @@ local function HandleBuff(self, auraInfo)
         -- user created indicators
         I.UpdateCustomIndicators(self, auraInfo)
 
-        -- check BG flags for statusIcon
-        if spellId == 156621 then
-            self.states.BGFlag = "alliance"
-        elseif spellId == 156618 then
-            self.states.BGFlag = "horde"
+        -- On Midnight in restricted context, spellId may be secret — can't use in equality comparisons
+        if not Cell.isMidnight or not F.IsAuraRestricted() then
+            -- check BG flags for statusIcon
+            if spellId == 156621 then
+                self.states.BGFlag = "alliance"
+            elseif spellId == 156618 then
+                self.states.BGFlag = "horde"
+            end
         end
     end
 end
@@ -1559,19 +1623,10 @@ end
 
 -------------------------------------------------
 -- check auras using CLEU
+-- NOTE: COMBAT_LOG_EVENT_UNFILTERED is unavailable on Midnight (12.0.0+).
+-- CheckCLEURequired has been removed; the cleu frame is guarded below.
 -------------------------------------------------
 local cleu = CreateFrame("Frame")
-
-function CheckCLEURequired()
-    if (Cell.vars.currentLayoutTable.indicators[Cell.defaults.indicatorIndices.externalCooldowns].enabled
-        or Cell.vars.currentLayoutTable.indicators[Cell.defaults.indicatorIndices.defensiveCooldowns].enabled
-        or Cell.vars.currentLayoutTable.indicators[Cell.defaults.indicatorIndices.allCooldowns].enabled)
-        and (I.IsDefensiveCooldown(55342) or I.IsExternalCooldown(414660)) then
-        cleu:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-    else
-        cleu:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-    end
-end
 
 local function UpdateMirrorImage(b, event)
     if event == "SPELL_AURA_APPLIED" then
@@ -1614,46 +1669,26 @@ local function UpdateMassBarrier(b, event)
     end
 end
 
-cleu:SetScript("OnEvent", function()
-    local _, subEvent, _, sourceGUID, _, sourceFlags, _, _, _, destFlags, _, spellId = CombatLogGetCurrentEventInfo()
+-- CLEU-based indicator tracking (mirror image, mass barrier).
+-- Unavailable on Midnight (12.0.0+); guarded by Cell.isMidnight.
+if not Cell.isMidnight then
+    cleu:SetScript("OnEvent", function()
+        local _, subEvent, _, sourceGUID, _, sourceFlags, _, _, _, destFlags, _, spellId = CombatLogGetCurrentEventInfo()
 
-    -- mirror image
-    if spellId == 55342 and F.IsFriend(sourceFlags) then
-        F.HandleUnitButton("guid", sourceGUID, UpdateMirrorImage, subEvent)
-    end
+        -- mirror image
+        if spellId == 55342 and F.IsFriend(sourceFlags) then
+            F.HandleUnitButton("guid", sourceGUID, UpdateMirrorImage, subEvent)
+        end
 
-    -- mass barrier (self), SPELL_CAST_SUCCESS
-    if spellId == 414660 and F.IsFriend(sourceFlags) then
-        F.HandleUnitButton("guid", sourceGUID, UpdateMassBarrier, "SPELL_CAST_SUCCESS")
-    end
-    if (subEvent == "SPELL_AURA_REMOVED" or subEvent == "SPELL_AURA_REFRESH") and SelfBarriers[spellId] and F.IsFriend(sourceFlags) then
-        F.HandleUnitButton("guid", sourceGUID, UpdateMassBarrier, "SPELL_AURA_REMOVED")
-    end
-
-    -- CLEU auras
-    -- if I.CheckCleuAura(spellId) and F.IsFriend(destFlags) then
-    --     local b1, b2 = F.GetUnitButtonByGUID(sourceGUID)
-    --     if subEvent == "SPELL_AURA_APPLIED" then
-    --         if b1 and b1.states.unit then
-    --             cleuUnits[b1.states.unit] = {GetTime(), unpack(I.CheckCleuAura(spellId))}
-    --             UnitButton_UpdateDebuffs(b1)
-    --         end
-    --         if b2 and b2.states.unit then
-    --             cleuUnits[b2.states.unit] = {GetTime(), unpack(I.CheckCleuAura(spellId))}
-    --             UnitButton_UpdateDebuffs(b2)
-    --         end
-    --     elseif subEvent == "SPELL_AURA_REMOVED" then
-    --         if b1 and b1.states.unit then
-    --             cleuUnits[b1.states.unit] = nil
-    --             UnitButton_UpdateDebuffs(b1)
-    --         end
-    --         if b2 and b2.states.unit then
-    --             cleuUnits[b2.states.unit] = nil
-    --             UnitButton_UpdateDebuffs(b2)
-    --         end
-    --     end
-    -- end
-end)
+        -- mass barrier (self), SPELL_CAST_SUCCESS
+        if spellId == 414660 and F.IsFriend(sourceFlags) then
+            F.HandleUnitButton("guid", sourceGUID, UpdateMassBarrier, "SPELL_CAST_SUCCESS")
+        end
+        if (subEvent == "SPELL_AURA_REMOVED" or subEvent == "SPELL_AURA_REFRESH") and SelfBarriers[spellId] and F.IsFriend(sourceFlags) then
+            F.HandleUnitButton("guid", sourceGUID, UpdateMassBarrier, "SPELL_AURA_REMOVED")
+        end
+    end)
+end
 
 -------------------------------------------------
 -- functions
@@ -1690,25 +1725,54 @@ UnitButton_UpdateAuras = function(self, updateInfo)
 
         if updateInfo.updatedAuraInstanceIDs then
             local aura
+            -- auraInstanceID is NOT secret and is safe to use as table key
             for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
-                if self._buffs_cache[auraInstanceID] then
-                    buffsChanged = true
-                    aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                    if aura then
-                        aura.oldExpirationTime = self._buffs_cache[auraInstanceID].expirationTime or 0
-                        aura.oldApplications = self._buffs_cache[auraInstanceID].applications
-                        self._buffs_cache[auraInstanceID] = aura
-                    end
-                elseif self._debuffs_cache[auraInstanceID] then
-                    debuffsChanged = true
-                    aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                    if aura then
-                        aura.oldExpirationTime = self._debuffs_cache[auraInstanceID].expirationTime or 0
-                        aura.oldApplications = self._debuffs_cache[auraInstanceID].applications
-                        self._debuffs_cache[auraInstanceID] = aura
+                if Cell.isMidnight then
+                    -- On Midnight, GetAuraDataByAuraInstanceID may be blocked when auras are restricted,
+                    -- and aura fields (expirationTime, applications) are secret — skip refresh detection
+                    if self._buffs_cache[auraInstanceID] then
+                        buffsChanged = true
+                        if not F.IsAuraRestricted() then
+                            -- GetAuraDataByAuraInstanceID is blocked when aura access is restricted
+                            aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                            if aura then
+                                self._buffs_cache[auraInstanceID] = aura
+                            end
+                        end
+                    elseif self._debuffs_cache[auraInstanceID] then
+                        debuffsChanged = true
+                        if not F.IsAuraRestricted() then
+                            aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                            if aura then
+                                self._debuffs_cache[auraInstanceID] = aura
+                            end
+                        end
+                    else
+                        if not F.IsAuraRestricted() then
+                            self._missing_auras[auraInstanceID] = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                        end
                     end
                 else
-                    self._missing_auras[auraInstanceID] = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                    -- Pre-Midnight: original logic with expirationTime/applications comparisons
+                    if self._buffs_cache[auraInstanceID] then
+                        buffsChanged = true
+                        aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                        if aura then
+                            aura.oldExpirationTime = self._buffs_cache[auraInstanceID].expirationTime or 0
+                            aura.oldApplications = self._buffs_cache[auraInstanceID].applications
+                            self._buffs_cache[auraInstanceID] = aura
+                        end
+                    elseif self._debuffs_cache[auraInstanceID] then
+                        debuffsChanged = true
+                        aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                        if aura then
+                            aura.oldExpirationTime = self._debuffs_cache[auraInstanceID].expirationTime or 0
+                            aura.oldApplications = self._debuffs_cache[auraInstanceID].applications
+                            self._debuffs_cache[auraInstanceID] = aura
+                        end
+                    else
+                        self._missing_auras[auraInstanceID] = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                    end
                 end
             end
         end
@@ -1746,47 +1810,96 @@ UnitButton_UpdateAuras = function(self, updateInfo)
     I.UpdateStatusIcon(self)
 end
 
+-- Updates the health prediction calculator for a button (Midnight 12.0.0+)
+local function UnitButton_UpdateCalculator(self)
+    local unit = self.states.displayedUnit
+    if not unit then return end
+    local calc = self.widgets.healthCalculator
+    if not calc then return end
+    UnitGetDetailedHealPrediction(unit, "player", calc)
+end
+
 local function UnitButton_UpdateHealthStates(self, diff)
     local unit = self.states.displayedUnit
 
-    local health = UnitHealth(unit) + (diff or 0)
-    local healthMax = UnitHealthMax(unit)
-    health = min(health, healthMax) --! diff
+    if Cell.isMidnight and self.widgets.healthCalculator then
+        -- MIDNIGHT PATH: use calculator — no arithmetic on secrets
+        UnitButton_UpdateCalculator(self)
+        -- Death detection uses non-secret boolean
+        self.states.wasDead = self.states.isDead
+        self.states.isDead = UnitIsDeadOrGhost(unit) or false
+        -- Fallback: use UnitIsDeadOrGhost which is always non-secret
+        self.states.wasDeadOrGhost = self.states.isDeadOrGhost
+        self.states.isDeadOrGhost = UnitIsDeadOrGhost(unit) or false
 
-    self.states.health = health
-    self.states.healthMax = healthMax
-    self.states.totalAbsorbs = UnitGetTotalAbsorbs(unit)
-    self.states.healAbsorbs = UnitGetTotalHealAbsorbs(unit)
-
-    if healthMax == 0 then
-        self.states.healthPercent = 0
-    else
-        self.states.healthPercent = health / healthMax
-    end
-
-    self.states.wasDead = self.states.isDead
-    self.states.isDead = health == 0
-    if self.states.wasDead ~= self.states.isDead then
-        UnitButton_UpdateStatusText(self)
-        I.UpdateStatusIcon_Resurrection(self)
-        if not self.states.isDead then
-            self.states.hasSoulstone = nil
-            I.UpdateStatusIcon(self)
+        -- Health text: use calculator secret values
+        if enabledIndicators["healthText"] then
+            local calc = self.widgets.healthCalculator
+            local health = calc:GetCurrentHealth()
+            local maxHealth = calc:GetMaximumHealth()
+            local totalAbsorbs = calc:GetTotalDamageAbsorbs()
+            local healAbsorbs = calc:GetTotalHealAbsorbs()
+            -- SetValue accepts secret values
+            self.indicators.healthText:SetValue(health, maxHealth, totalAbsorbs, healAbsorbs)
+            self.indicators.healthText:Show()
+        else
+            self.indicators.healthText:Hide()
         end
-    end
 
-    self.states.wasDeadOrGhost = self.states.isDeadOrGhost
-    self.states.isDeadOrGhost = UnitIsDeadOrGhost(unit)
-    if self.states.wasDeadOrGhost ~= self.states.isDeadOrGhost then
-        I.UpdateStatusIcon_Resurrection(self)
-        UnitButton_UpdateHealthColor(self)
-    end
-
-    if enabledIndicators["healthText"] then -- and not self.states.isDeadOrGhost then
-        self.indicators.healthText:SetValue(health, healthMax, self.states.totalAbsorbs, self.states.healAbsorbs)
-        self.indicators.healthText:Show()
+        -- Fire death-state change callbacks
+        if self.states.wasDead ~= self.states.isDead then
+            UnitButton_UpdateStatusText(self)
+            I.UpdateStatusIcon_Resurrection(self)
+            if not self.states.isDead then
+                self.states.hasSoulstone = nil
+                I.UpdateStatusIcon(self)
+            end
+        end
+        if self.states.wasDeadOrGhost ~= self.states.isDeadOrGhost then
+            I.UpdateStatusIcon_Resurrection(self)
+            UnitButton_UpdateHealthColor(self)
+        end
     else
-        self.indicators.healthText:Hide()
+        -- CLASSIC/PRE-MIDNIGHT PATH: original logic preserved
+        local health = UnitHealth(unit) + (diff or 0)
+        local healthMax = UnitHealthMax(unit)
+        health = min(health, healthMax) --! diff
+
+        self.states.health = health
+        self.states.healthMax = healthMax
+        self.states.totalAbsorbs = UnitGetTotalAbsorbs(unit)
+        self.states.healAbsorbs = UnitGetTotalHealAbsorbs(unit)
+
+        if healthMax == 0 then
+            self.states.healthPercent = 0
+        else
+            self.states.healthPercent = health / healthMax
+        end
+
+        self.states.wasDead = self.states.isDead
+        self.states.isDead = health == 0
+        if self.states.wasDead ~= self.states.isDead then
+            UnitButton_UpdateStatusText(self)
+            I.UpdateStatusIcon_Resurrection(self)
+            if not self.states.isDead then
+                self.states.hasSoulstone = nil
+                I.UpdateStatusIcon(self)
+            end
+        end
+
+        self.states.wasDeadOrGhost = self.states.isDeadOrGhost
+        self.states.isDeadOrGhost = UnitIsDeadOrGhost(unit)
+        if self.states.wasDeadOrGhost ~= self.states.isDeadOrGhost then
+            I.UpdateStatusIcon_Resurrection(self)
+            UnitButton_UpdateHealthColor(self)
+        end
+
+        if enabledIndicators["healthText"] then -- and not self.states.isDeadOrGhost then
+            self.indicators.healthText:SetValue(health, healthMax, self.states.totalAbsorbs, self.states.healAbsorbs)
+            self.indicators.healthText:Show()
+        else
+            self.indicators.healthText:Hide()
+        end
     end
 end
 
@@ -1973,7 +2086,10 @@ local function CheckVehicleRoot(self, petUnit)
     local isRoot
     for i = 1, UnitVehicleSeatCount(playerUnit) do
         local controlType, occupantName, serverName, ejectable, canSwitchSeats = UnitVehicleSeatInfo(playerUnit, i)
-        if UnitName(playerUnit) == occupantName then
+        local pName = UnitName(playerUnit)
+        -- On Midnight 12.0.0+, UnitName() may return a secret string in instances
+        -- Comparing a secret string with == will error, so guard before comparing
+        if not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(pName)) and pName == occupantName then
             isRoot = controlType == "Root"
             break
         end
@@ -2100,6 +2216,9 @@ UnitButton_UpdatePowerText = function(self)
     if not self._shouldShowPowerText then return end
 
     if self.states.powerMax and self.states.power and not self.states.isDeadOrGhost then
+        -- On Midnight, power and powerMax may be secret values (Midnight 12.0.0+)
+        -- SetValue uses string.format/AbbreviateNumbers which accept secrets → FontString:SetText accepts secrets
+        -- Secret handling is in the powerText indicator's SetValue method (Indicators/Base.lua) — Phase 8 follow-up
         self.indicators.powerText:SetValue(self.states.power, self.states.powerMax)
     else
         self.indicators.powerText:Hide()
@@ -2124,6 +2243,8 @@ end
 UnitButton_UpdatePowerMax = function(self)
     if not (self._shouldShowPowerBar and self.states.powerMax) then return end
 
+    -- powerMax is non-secret for player units; may be secret for some NPCs in instances (Midnight 12.0.0+)
+    -- SetMinMaxValues/SetMinMaxSmoothedValue accept secrets; pass through directly
     if barAnimationType == "Smooth" then
         self.widgets.powerBar:SetMinMaxSmoothedValue(0, self.states.powerMax)
     else
@@ -2134,6 +2255,8 @@ end
 UnitButton_UpdatePower = function(self)
     if not (self._shouldShowPowerBar and self.states.power) then return end
 
+    -- self.states.power may be a secret value on Midnight 12.0.0+
+    -- SetValue/SetBarValue accepts secrets, so no change needed here
     self.widgets.powerBar:SetBarValue(self.states.power)
 end
 
@@ -2163,10 +2286,34 @@ local function UnitButton_UpdateHealthMax(self)
 
     UnitButton_UpdateHealthStates(self)
 
-    if barAnimationType == "Smooth" then
-        self.widgets.healthBar:SetMinMaxSmoothedValue(0, self.states.healthMax)
+    if Cell.isMidnight and self.widgets.healthCalculator then
+        -- MIDNIGHT PATH: pass secret maxHealth directly
+        local maxHealth = self.widgets.healthCalculator:GetMaximumHealth()
+        if barAnimationType == "Smooth" then
+            self.widgets.healthBar:SetMinMaxSmoothedValue(0, maxHealth)
+        else
+            self.widgets.healthBar:SetMinMaxValues(0, maxHealth) -- TODO: test SetMinMaxValues with secret max on PTR
+        end
+        -- Also update overlay bar ranges
+        if self.widgets.incomingHeal then
+            self.widgets.incomingHeal:SetMinMaxValues(0, maxHealth)
+        end
+        if self.widgets.shieldBar then
+            self.widgets.shieldBar:SetMinMaxValues(0, maxHealth)
+        end
+        if self.widgets.shieldBarR then
+            self.widgets.shieldBarR:SetMinMaxValues(0, maxHealth)
+        end
+        if self.widgets.absorbsBar then
+            self.widgets.absorbsBar:SetMinMaxValues(0, maxHealth)
+        end
     else
-        self.widgets.healthBar:SetMinMaxValues(0, self.states.healthMax)
+        -- CLASSIC/PRE-MIDNIGHT PATH: original logic
+        if barAnimationType == "Smooth" then
+            self.widgets.healthBar:SetMinMaxSmoothedValue(0, self.states.healthMax)
+        else
+            self.widgets.healthBar:SetMinMaxValues(0, self.states.healthMax)
+        end
     end
 
     if Cell.vars.useThresholdColor or Cell.vars.useFullColor then
@@ -2182,42 +2329,100 @@ local function UnitButton_UpdateHealth(self, diff, skipStateUpdates)
         UnitButton_UpdateHealthStates(self, diff)
     end
 
-    local healthPercent = self.states.healthPercent
-
-    if barAnimationType == "Flash" then
-        self.widgets.healthBar:SetValue(self.states.health)
-        local diff = healthPercent - (self.states.healthPercentOld or healthPercent)
-        if diff >= 0 or self.states.healthMax == 0 then
+    if Cell.isMidnight and self.widgets.healthCalculator then
+        -- MIDNIGHT PATH: pass secret values directly to status bar
+        local calc = self.widgets.healthCalculator
+        local health = calc:GetCurrentHealth()
+        -- SetValue accepts secrets
+        if barAnimationType == "Flash" then
+            self.widgets.healthBar:SetValue(health)
+            -- Flash: we can't compute exact diff without arithmetic on secrets, so skip precise flash
             B.HideFlash(self)
-        elseif diff <= -0.05 and diff >= -1 then --! player (just joined) UnitHealthMax(unit) may be 1 ====> diff == -maxHealth
-            B.ShowFlash(self, abs(diff))
+        else
+            self.widgets.healthBar:SetBarValue(health)
+        end
+
+        if Cell.vars.useThresholdColor or Cell.vars.useFullColor then
+            UnitButton_UpdateHealthColor(self)
+        end
+
+        -- Health thresholds: use EvaluateCurrentHealthPercent with a curve
+        if enabledIndicators["healthThresholds"] and self.widgets.healthCalculator then
+            self.indicators.healthThresholds:CheckThresholdMidnight(self.widgets.healthCalculator)
+        else
+            self.indicators.healthThresholds:Hide()
+        end
+
+        -- CELL_FADE_OUT_HEALTH_PERCENT: use EvaluateMissingHealthPercent with a Curve to fade
+        -- frames that are above the health threshold (healthy enough to fade out)
+        if CELL_FADE_OUT_HEALTH_PERCENT and self.widgets.healthCalculator then
+            RebuildFadeOutHealthCurve()
+            if fadeOutHealthCurve and self.states.inRange then
+                -- EvaluateCurrentHealthPercent feeds secret health% into the curve
+                -- Curve output: 1.0 if below threshold (needs healing), outOfRangeAlpha if above
+                local targetAlpha = self.widgets.healthCalculator:EvaluateCurrentHealthPercent(fadeOutHealthCurve)
+                -- targetAlpha is a secret value — SetAlpha accepts secrets on Midnight
+                self:SetAlpha(targetAlpha)
+            end
         end
     else
-        self.widgets.healthBar:SetBarValue(self.states.health)
-    end
+        -- CLASSIC/PRE-MIDNIGHT PATH: original logic
+        local healthPercent = self.states.healthPercent
 
-    if Cell.vars.useThresholdColor or Cell.vars.useFullColor then
-        UnitButton_UpdateHealthColor(self)
-    end
-
-    self.states.healthPercentOld = healthPercent
-
-    if enabledIndicators["healthThresholds"] then
-        self.indicators.healthThresholds:CheckThreshold(healthPercent)
-    else
-        self.indicators.healthThresholds:Hide()
-    end
-
-    if CELL_FADE_OUT_HEALTH_PERCENT then
-        if self.states.inRange and healthPercent < CELL_FADE_OUT_HEALTH_PERCENT then
-            A.FrameFadeIn(self, 0.25, self:GetAlpha(), 1)
+        if barAnimationType == "Flash" then
+            self.widgets.healthBar:SetValue(self.states.health)
+            local diff = healthPercent - (self.states.healthPercentOld or healthPercent)
+            if diff >= 0 or self.states.healthMax == 0 then
+                B.HideFlash(self)
+            elseif diff <= -0.05 and diff >= -1 then --! player (just joined) UnitHealthMax(unit) may be 1 ====> diff == -maxHealth
+                B.ShowFlash(self, abs(diff))
+            end
         else
-            A.FrameFadeOut(self, 0.25, self:GetAlpha(), CellDB["appearance"]["outOfRangeAlpha"])
+            self.widgets.healthBar:SetBarValue(self.states.health)
+        end
+
+        if Cell.vars.useThresholdColor or Cell.vars.useFullColor then
+            UnitButton_UpdateHealthColor(self)
+        end
+
+        self.states.healthPercentOld = healthPercent
+
+        if enabledIndicators["healthThresholds"] then
+            self.indicators.healthThresholds:CheckThreshold(healthPercent)
+        else
+            self.indicators.healthThresholds:Hide()
+        end
+
+        if CELL_FADE_OUT_HEALTH_PERCENT then
+            if self.states.inRange and healthPercent < CELL_FADE_OUT_HEALTH_PERCENT then
+                A.FrameFadeIn(self, 0.25, self:GetAlpha(), 1)
+            else
+                A.FrameFadeOut(self, 0.25, self:GetAlpha(), CellDB["appearance"]["outOfRangeAlpha"])
+            end
         end
     end
 end
 
 local function UnitButton_UpdateHealPrediction(self, skipStateUpdates)
+    if Cell.isMidnight and self.widgets.healthCalculator then
+        -- MIDNIGHT PATH: use calculator secret values
+        if not predictionEnabled then
+            self.widgets.incomingHeal:Hide()
+            return
+        end
+        local unit = self.states.displayedUnit
+        if not unit then return end
+        -- Refresh calculator so we have current data (critical for standalone UNIT_HEAL_PREDICTION events)
+        UnitButton_UpdateCalculator(self)
+        -- GetIncomingHeals returns: amount (all healers), amountFromHealer, amountFromOthers, clamped
+        -- We use the first return (amount) which includes heals from ALL healers in the raid
+        local incomingHeals = self.widgets.healthCalculator:GetIncomingHeals()
+        self.widgets.incomingHeal:SetValue(incomingHeals)
+        self.widgets.incomingHeal:Show()
+        return
+    end
+
+    -- CLASSIC/PRE-MIDNIGHT PATH: original logic
     if not predictionEnabled then
         self.widgets.incomingHeal:Hide()
         return
@@ -2240,6 +2445,63 @@ local function UnitButton_UpdateHealPrediction(self, skipStateUpdates)
 end
 
 UnitButton_UpdateShieldAbsorbs = function(self, skipStateUpdates)
+    if Cell.isMidnight and self.widgets.healthCalculator then
+        -- MIDNIGHT PATH: use calculator secret values
+        if not shieldEnabled then
+            self.widgets.shieldBar:Hide()
+            self.widgets.shieldBarR:Hide()
+            self.widgets.overShieldGlow:Hide()
+            self.widgets.overShieldGlowR:Hide()
+            self.indicators.shieldBar:Hide()
+            return
+        end
+        local unit = self.states.displayedUnit
+        if not unit then return end
+        -- Refresh calculator so we have current data (critical for standalone UNIT_ABSORB_AMOUNT_CHANGED events)
+        UnitButton_UpdateCalculator(self)
+        local absorbs = self.widgets.healthCalculator:GetDamageAbsorbs()
+        -- Update the shield widget bars
+        self.widgets.shieldBar:SetValue(absorbs)
+        self.widgets.shieldBar:Show()
+
+        -- Overshield glow and reverse-fill bar
+        -- NOTE: absorbs is a secret value on Midnight — we can't compare it to health to detect overshield.
+        -- Show the glow whenever shields are present and overshieldEnabled is on.
+        -- TODO: Use a Curve to map (absorbs + health - maxHealth) to glow visibility for precise overshield detection.
+        if overshieldReverseFillEnabled then
+            self.widgets.shieldBarR:SetValue(absorbs)
+            self.widgets.shieldBarR:Show()
+            if overshieldEnabled then
+                self.widgets.overShieldGlowR:Show()
+            else
+                self.widgets.overShieldGlowR:Hide()
+            end
+            self.widgets.overShieldGlow:Hide()
+        else
+            if overshieldEnabled then
+                self.widgets.overShieldGlow:Show()
+            else
+                self.widgets.overShieldGlow:Hide()
+            end
+            self.widgets.shieldBarR:Hide()
+            self.widgets.overShieldGlowR:Hide()
+        end
+
+        -- Update shield indicator (user-configurable indicator on top of health bar)
+        if enabledIndicators["shieldBar"] then
+            -- On Midnight, we pass the secret absorb value directly; the indicator's SetValue
+            -- accepts secrets since it's backed by a StatusBar on Midnight.
+            -- NOTE: indicatorBooleans["shieldBar"] (onlyShowOvershields) can't be honored with
+            -- secrets since we can't compute overshieldPercent. Show full absorbs instead.
+            self.indicators.shieldBar:Show()
+            self.indicators.shieldBar:SetValue(absorbs)
+        else
+            self.indicators.shieldBar:Hide()
+        end
+        return
+    end
+
+    -- CLASSIC/PRE-MIDNIGHT PATH: original logic
     local unit = self.states.displayedUnit
     if not unit then return end
 
@@ -2279,6 +2541,24 @@ UnitButton_UpdateShieldAbsorbs = function(self, skipStateUpdates)
 end
 
 local function UnitButton_UpdateHealAbsorbs(self, skipStateUpdates)
+    if Cell.isMidnight and self.widgets.healthCalculator then
+        -- MIDNIGHT PATH: use calculator secret values
+        if not absorbEnabled then
+            self.widgets.absorbsBar:Hide()
+            self.widgets.overAbsorbGlow:Hide()
+            return
+        end
+        local unit = self.states.displayedUnit
+        if not unit then return end
+        -- Refresh calculator so we have current data (critical for standalone UNIT_HEAL_ABSORB_AMOUNT_CHANGED events)
+        UnitButton_UpdateCalculator(self)
+        local healAbsorbs = self.widgets.healthCalculator:GetHealAbsorbs()
+        self.widgets.absorbsBar:SetValue(healAbsorbs)
+        self.widgets.absorbsBar:Show()
+        return
+    end
+
+    -- CLASSIC/PRE-MIDNIGHT PATH: original logic
     if not absorbEnabled then
         self.widgets.absorbsBar:Hide()
         self.widgets.overAbsorbGlow:Hide()
@@ -2365,7 +2645,16 @@ local function UnitButton_UpdateInRange(self, ir)
         if self.states.inRange ~= self.states.wasInRange then
             if inRange then
                 if CELL_FADE_OUT_HEALTH_PERCENT then
-                    if not self.states.healthPercent or self.states.healthPercent < CELL_FADE_OUT_HEALTH_PERCENT then
+                    if Cell.isMidnight and self.widgets and self.widgets.healthCalculator then
+                        -- Midnight: use Curve-based fade (secret-safe)
+                        RebuildFadeOutHealthCurve()
+                        if fadeOutHealthCurve then
+                            local targetAlpha = self.widgets.healthCalculator:EvaluateCurrentHealthPercent(fadeOutHealthCurve)
+                            self:SetAlpha(targetAlpha)
+                        else
+                            A.FrameFadeIn(self, 0.25, self:GetAlpha(), 1)
+                        end
+                    elseif not self.states.healthPercent or self.states.healthPercent < CELL_FADE_OUT_HEALTH_PERCENT then
                         A.FrameFadeIn(self, 0.25, self:GetAlpha(), 1)
                     else
                         A.FrameFadeOut(self, 0.25, self:GetAlpha(), CellDB["appearance"]["outOfRangeAlpha"])
@@ -2466,6 +2755,9 @@ local function UnitButton_UpdateName(self)
     local unit = self.states.unit
     if not unit then return end
 
+    -- unit name may be a secret string in instances on Midnight 12.0.0+
+    -- FontString:SetText() accepts secrets, so display works without change
+    -- However, any NAME COMPARISONS (name == something) will error if name is secret
     self.states.name = UnitName(unit)
     self.states.fullName = F.UnitFullName(unit)
     self.states.class = UnitClassBase(unit)
@@ -2502,6 +2794,11 @@ UnitButton_UpdateHealthColor = function(self)
     local unit = self.states.unit
     if not unit then return end
 
+    -- NOTE: Health bar coloring uses non-secret data (class, settings, UnitIsPlayer, etc.)
+    -- so the classic color logic below works on both Midnight and pre-Midnight.
+    -- TODO: implement proper ColorCurve coloring for threshold/gradient modes once
+    -- SetStatusBarColor secret color API is verified on PTR.
+
     self.states.class = UnitClassBase(unit) --! update class
 
     local barR, barG, barB
@@ -2534,53 +2831,35 @@ UnitButton_UpdateHealthColor = function(self)
     self.widgets.healthBar:SetStatusBarColor(barR, barG, barB, barA)
     self.widgets.healthBarLoss:SetVertexColor(lossR, lossG, lossB, lossA)
 
-    if Cell.loaded and CellDB["appearance"]["healPrediction"][2] then
-        self.widgets.incomingHeal:SetVertexColor(CellDB["appearance"]["healPrediction"][3][1], CellDB["appearance"]["healPrediction"][3][2], CellDB["appearance"]["healPrediction"][3][3], CellDB["appearance"]["healPrediction"][3][4])
+    if Cell.isMidnight then
+        -- StatusBar on Midnight: use SetStatusBarColor
+        if Cell.loaded and CellDB["appearance"]["healPrediction"][2] then
+            self.widgets.incomingHeal:SetStatusBarColor(CellDB["appearance"]["healPrediction"][3][1], CellDB["appearance"]["healPrediction"][3][2], CellDB["appearance"]["healPrediction"][3][3], CellDB["appearance"]["healPrediction"][3][4])
+        else
+            self.widgets.incomingHeal:SetStatusBarColor(barR, barG, barB, 0.4)
+        end
     else
-        self.widgets.incomingHeal:SetVertexColor(barR, barG, barB, 0.4)
+        -- Texture on pre-Midnight: use SetVertexColor
+        if Cell.loaded and CellDB["appearance"]["healPrediction"][2] then
+            self.widgets.incomingHeal:SetVertexColor(CellDB["appearance"]["healPrediction"][3][1], CellDB["appearance"]["healPrediction"][3][2], CellDB["appearance"]["healPrediction"][3][3], CellDB["appearance"]["healPrediction"][3][4])
+        else
+            self.widgets.incomingHeal:SetVertexColor(barR, barG, barB, 0.4)
+        end
     end
 end
 
--------------------------------------------------
--- cleu health updater
--------------------------------------------------
-local cleuHealthUpdater = CreateFrame("Frame", "CellCleuHealthUpdater")
-cleuHealthUpdater:SetScript("OnEvent", function()
-    local _, subEvent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22 = CombatLogGetCurrentEventInfo()
-
-    if not F.IsFriend(destFlags) then return end
-
-    local diff
-    if subEvent == "SPELL_HEAL" or subEvent == "SPELL_PERIODIC_HEAL" then
-        -- spellId, spellName, spellSchool, amount, overhealing, absorbed, critical
-        diff = arg15
-    elseif subEvent == "SPELL_DAMAGE" or subEvent == "SPELL_PERIODIC_DAMAGE" then
-        -- spellId, spellName, spellSchool, amount, overhealing, absorbed, critical
-        diff = -arg15
-    elseif subEvent == "SWING_DAMAGE" then
-        -- amount
-        diff = -arg12
-    elseif subEvent == "RANGE_DAMAGE" then
-        -- spellId, spellName, spellSchool, amount
-        diff = -arg15
-    elseif subEvent == "ENVIRONMENTAL_DAMAGE" then
-        -- environmentalType, amount
-        diff = -arg13
-    end
-
-    if diff and diff ~= 0 then
-        F.HandleUnitButton("guid", destGUID, UnitButton_UpdateHealth, diff)
-    end
-end)
-
-local function UpdateCLEU()
-    if CellDB["general"]["useCleuHealthUpdater"] then
-        cleuHealthUpdater:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-    else
-        cleuHealthUpdater:UnregisterAllEvents()
-    end
+-- Configures the health color curve for a button (Midnight 12.0.0+)
+-- Called when color settings change (e.g., class color, custom color toggled)
+function B.UpdateHealthColorCurve(button)
+    if not (Cell.isMidnight and button.widgets.healthColorCurve) then return end
+    local curve = button.widgets.healthColorCurve
+    curve:ClearPoints()
+    -- Default green gradient; overridden by class color / custom color settings
+    -- TODO: read from CellDB["appearance"] color settings and build proper curve
+    curve:AddPoint(0.0, {r=1,   g=0,   b=0,   a=1}) -- red at 0%
+    curve:AddPoint(0.5, {r=1,   g=1,   b=0,   a=1}) -- yellow at 50%
+    curve:AddPoint(1.0, {r=0,   g=0.9, b=0,   a=1}) -- green at 100%
 end
-Cell.RegisterCallback("UpdateCLEU", "UnitButton_UpdateCLEU", UpdateCLEU)
 
 -------------------------------------------------
 -- translit names
@@ -2892,6 +3171,10 @@ local function UnitButton_OnAttributeChanged(self, name, value)
                 self.__unitName = nil
             end
             wipe(self.states)
+            -- Reset calculator predicted values to prevent stale data from previous unit
+            if self.widgets and self.widgets.healthCalculator then
+                self.widgets.healthCalculator:ResetPredictedValues()
+            end
         end
 
         -- private auras
@@ -2976,6 +3259,10 @@ local function UnitButton_OnHide(self)
     self.__displayedGuid = nil
     self._updateRequired = nil
     F.RemoveElementsExceptKeys(self.states, "unit", "displayedUnit")
+    -- Reset calculator predicted values so hidden button doesn't hold stale data
+    if self.widgets and self.widgets.healthCalculator then
+        self.widgets.healthCalculator:ResetPredictedValues()
+    end
 end
 
 local function UnitButton_OnEnter(self)
@@ -3020,7 +3307,13 @@ local function UnitButton_OnTick(self)
                 -- NOTE: unit entity changed
                 -- update Cell.vars.guids
                 self.__unitGuid = guid
-                if not self.isSpotlight then Cell.vars.guids[guid] = self.states.unit end
+                -- On Midnight 12.0.0+, GUIDs for non-player units in instances are secret
+                -- Can't use a secret as a table key — only store non-secret GUIDs
+                if not self.isSpotlight then
+                    if not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid)) then
+                        Cell.vars.guids[guid] = self.states.unit
+                    end
+                end
 
                 -- NOTE: only save players' names
                 if UnitIsPlayer(self.states.unit) then
@@ -3098,13 +3391,25 @@ function B.UpdateShields(button)
     absorbEnabled = CellDB["appearance"]["healAbsorb"][1]
     absorbInvertColor = CellDB["appearance"]["healAbsorbInvertColor"]
 
-    button.widgets.shieldBar:SetVertexColor(unpack(CellDB["appearance"]["shield"][2]))
-    button.widgets.shieldBarR:SetVertexColor(unpack(CellDB["appearance"]["shield"][2]))
+    if Cell.isMidnight then
+        -- StatusBars on Midnight: use SetStatusBarColor
+        button.widgets.shieldBar:SetStatusBarColor(unpack(CellDB["appearance"]["shield"][2]))
+        button.widgets.shieldBarR:SetStatusBarColor(unpack(CellDB["appearance"]["shield"][2]))
+    else
+        -- Textures on pre-Midnight: use SetVertexColor
+        button.widgets.shieldBar:SetVertexColor(unpack(CellDB["appearance"]["shield"][2]))
+        button.widgets.shieldBarR:SetVertexColor(unpack(CellDB["appearance"]["shield"][2]))
+    end
+    -- overShieldGlow textures are always textures
     button.widgets.overShieldGlow:SetVertexColor(unpack(CellDB["appearance"]["overshield"][2]))
     button.widgets.overShieldGlowR:SetVertexColor(unpack(CellDB["appearance"]["overshield"][2]))
     if not absorbInvertColor then
         button.widgets.overAbsorbGlow:SetVertexColor(unpack(CellDB["appearance"]["healAbsorb"][2]))
-        button.widgets.absorbsBar:SetVertexColor(unpack(CellDB["appearance"]["healAbsorb"][2]))
+        if Cell.isMidnight then
+            button.widgets.absorbsBar:SetStatusBarColor(unpack(CellDB["appearance"]["healAbsorb"][2]))
+        else
+            button.widgets.absorbsBar:SetVertexColor(unpack(CellDB["appearance"]["healAbsorb"][2]))
+        end
     end
 
     UnitButton_UpdateHealPrediction(button)
@@ -3119,7 +3424,11 @@ function B.SetTexture(button, tex)
     button.widgets.powerBar:SetStatusBarTexture(tex)
     button.widgets.powerBar:GetStatusBarTexture():SetDrawLayer("ARTWORK", -7) --! VERY IMPORTANT
     button.widgets.powerBarLoss:SetTexture(tex)
-    button.widgets.incomingHeal:SetTexture(tex)
+    if Cell.isMidnight then
+        button.widgets.incomingHeal:SetStatusBarTexture(tex)
+    else
+        button.widgets.incomingHeal:SetTexture(tex)
+    end
     button.widgets.damageFlashTex:SetTexture(tex)
 end
 
@@ -3344,14 +3653,14 @@ function B.SetOrientation(button, orientation, rotateTexture)
     if rotateTexture then
         F.RotateTexture(healthBarLoss, 90)
         F.RotateTexture(powerBarLoss, 90)
-        F.RotateTexture(incomingHeal, 90)
+        if not Cell.isMidnight then F.RotateTexture(incomingHeal, 90) end
         F.RotateTexture(damageFlashTex, 90)
         -- F.RotateTexture(shieldBar, 90)
         -- F.RotateTexture(absorbsBar, 90)
     else
         F.RotateTexture(healthBarLoss, 0)
         F.RotateTexture(powerBarLoss, 0)
-        F.RotateTexture(incomingHeal, 0)
+        if not Cell.isMidnight then F.RotateTexture(incomingHeal, 0) end
         F.RotateTexture(damageFlashTex, 0)
         -- F.RotateTexture(overShieldGlow, 0)
         -- F.RotateTexture(shieldBar, 0)
@@ -3375,28 +3684,37 @@ function B.SetOrientation(button, orientation, rotateTexture)
         P.Point(gapTexture, "BOTTOMRIGHT", powerBar, "TOPRIGHT")
         P.Height(gapTexture, CELL_BORDER_SIZE)
 
-        -- update incomingHeal
-        incomingHeal.SetValue = IncomingHeal_SetValue_Horizontal
-        P.ClearPoints(incomingHeal)
-        P.Point(incomingHeal, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
-        P.Point(incomingHeal, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "BOTTOMRIGHT")
+        if Cell.isMidnight then
+            -- Midnight: StatusBars use SetAllPoints(healthBar) + native fill; just set orientation
+            incomingHeal:SetOrientation("horizontal")
+            shieldBar:SetOrientation("horizontal")
+            shieldBarR:SetOrientation("horizontal")
+            absorbsBar:SetOrientation("horizontal")
+        else
+            -- Pre-Midnight: Textures with manual positioning
+            -- update incomingHeal
+            incomingHeal.SetValue = IncomingHeal_SetValue_Horizontal
+            P.ClearPoints(incomingHeal)
+            P.Point(incomingHeal, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+            P.Point(incomingHeal, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "BOTTOMRIGHT")
 
-        -- update shieldBar
-        shieldBar.SetValue = ShieldBar_SetValue_Horizontal
-        P.ClearPoints(shieldBar)
-        P.Point(shieldBar, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
-        P.Point(shieldBar, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "BOTTOMRIGHT")
+            -- update shieldBar
+            shieldBar.SetValue = ShieldBar_SetValue_Horizontal
+            P.ClearPoints(shieldBar)
+            P.Point(shieldBar, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+            P.Point(shieldBar, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "BOTTOMRIGHT")
 
-        -- update shieldBarR
-        P.ClearPoints(shieldBarR)
-        P.Point(shieldBarR, "TOPRIGHT", healthBar:GetStatusBarTexture())
-        P.Point(shieldBarR, "BOTTOMRIGHT", healthBar:GetStatusBarTexture())
+            -- update shieldBarR
+            P.ClearPoints(shieldBarR)
+            P.Point(shieldBarR, "TOPRIGHT", healthBar:GetStatusBarTexture())
+            P.Point(shieldBarR, "BOTTOMRIGHT", healthBar:GetStatusBarTexture())
 
-        -- update absorbsBar
-        absorbsBar.SetValue = AbsorbsBar_SetValue_Horizontal
-        P.ClearPoints(absorbsBar)
-        P.Point(absorbsBar, "TOPRIGHT", healthBar:GetStatusBarTexture())
-        P.Point(absorbsBar, "BOTTOMRIGHT", healthBar:GetStatusBarTexture())
+            -- update absorbsBar
+            absorbsBar.SetValue = AbsorbsBar_SetValue_Horizontal
+            P.ClearPoints(absorbsBar)
+            P.Point(absorbsBar, "TOPRIGHT", healthBar:GetStatusBarTexture())
+            P.Point(absorbsBar, "BOTTOMRIGHT", healthBar:GetStatusBarTexture())
+        end
 
         -- update overShieldGlow
         P.ClearPoints(overShieldGlow)
@@ -3454,28 +3772,37 @@ function B.SetOrientation(button, orientation, rotateTexture)
             P.Height(gapTexture, CELL_BORDER_SIZE)
         end
 
-        -- update incomingHeal
-        incomingHeal.SetValue = IncomingHeal_SetValue_Vertical
-        P.ClearPoints(incomingHeal)
-        P.Point(incomingHeal, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "TOPLEFT")
-        P.Point(incomingHeal, "BOTTOMRIGHT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+        if Cell.isMidnight then
+            -- Midnight: StatusBars use SetAllPoints(healthBar) + native fill; just set orientation
+            incomingHeal:SetOrientation("vertical")
+            shieldBar:SetOrientation("vertical")
+            shieldBarR:SetOrientation("vertical")
+            absorbsBar:SetOrientation("vertical")
+        else
+            -- Pre-Midnight: Textures with manual positioning
+            -- update incomingHeal
+            incomingHeal.SetValue = IncomingHeal_SetValue_Vertical
+            P.ClearPoints(incomingHeal)
+            P.Point(incomingHeal, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "TOPLEFT")
+            P.Point(incomingHeal, "BOTTOMRIGHT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
 
-        -- update shieldBar
-        shieldBar.SetValue = ShieldBar_SetValue_Vertical
-        P.ClearPoints(shieldBar)
-        P.Point(shieldBar, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "TOPLEFT")
-        P.Point(shieldBar, "BOTTOMRIGHT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+            -- update shieldBar
+            shieldBar.SetValue = ShieldBar_SetValue_Vertical
+            P.ClearPoints(shieldBar)
+            P.Point(shieldBar, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "TOPLEFT")
+            P.Point(shieldBar, "BOTTOMRIGHT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
 
-        -- update shieldBarR
-        P.ClearPoints(shieldBarR)
-        P.Point(shieldBarR, "TOPLEFT", healthBar:GetStatusBarTexture())
-        P.Point(shieldBarR, "TOPRIGHT", healthBar:GetStatusBarTexture())
+            -- update shieldBarR
+            P.ClearPoints(shieldBarR)
+            P.Point(shieldBarR, "TOPLEFT", healthBar:GetStatusBarTexture())
+            P.Point(shieldBarR, "TOPRIGHT", healthBar:GetStatusBarTexture())
 
-        -- update absorbsBar
-        absorbsBar.SetValue = AbsorbsBar_SetValue_Vertical
-        P.ClearPoints(absorbsBar)
-        P.Point(absorbsBar, "TOPLEFT", healthBar:GetStatusBarTexture())
-        P.Point(absorbsBar, "TOPRIGHT", healthBar:GetStatusBarTexture())
+            -- update absorbsBar
+            absorbsBar.SetValue = AbsorbsBar_SetValue_Vertical
+            P.ClearPoints(absorbsBar)
+            P.Point(absorbsBar, "TOPLEFT", healthBar:GetStatusBarTexture())
+            P.Point(absorbsBar, "TOPRIGHT", healthBar:GetStatusBarTexture())
+        end
 
         -- update overShieldGlow
         P.ClearPoints(overShieldGlow)
@@ -3732,6 +4059,15 @@ function CellUnitButton_OnLoad(button)
     button.states = {}
     button.indicators = {}
 
+    -- Health prediction calculator (Patch 12.0.0+)
+    if Cell.isMidnight and CreateUnitHealPredictionCalculator then
+        button.widgets.healthCalculator = CreateUnitHealPredictionCalculator()
+    end
+    -- Color curve for health bar coloring (Patch 12.0.0+)
+    if Cell.isMidnight and C_CurveUtil then
+        button.widgets.healthColorCurve = C_CurveUtil.CreateColorCurve()
+    end
+
     InitAuraTables(button)
 
     -- ping system
@@ -3806,11 +4142,25 @@ function CellUnitButton_OnLoad(button)
     powerBarLoss:SetTexture(Cell.vars.texture)
 
     -- incoming heal
-    local incomingHeal = healthBar:CreateTexture(name.."IncomingHealBar", "ARTWORK", nil, -6)
+    local incomingHeal
+    if Cell.isMidnight then
+        -- Midnight: StatusBar so native SetMinMaxValues/SetValue work with secret values
+        incomingHeal = CreateFrame("StatusBar", name.."IncomingHealBar", healthBar)
+        incomingHeal:SetStatusBarTexture(Cell.vars.texture)
+        incomingHeal:GetStatusBarTexture():SetDrawLayer("ARTWORK", -6)
+        incomingHeal:SetFrameLevel(healthBar:GetFrameLevel()+1)
+        incomingHeal:SetAllPoints(healthBar)
+        -- Compatibility shims: map Texture methods to StatusBar equivalents
+        incomingHeal.SetVertexColor = incomingHeal.SetStatusBarColor
+        incomingHeal.SetTexture = incomingHeal.SetStatusBarTexture
+    else
+        -- Pre-Midnight: Texture with manual width/height positioning
+        incomingHeal = healthBar:CreateTexture(name.."IncomingHealBar", "ARTWORK", nil, -6)
+        incomingHeal:SetTexture(Cell.vars.texture)
+        incomingHeal.SetValue = DumbFunc
+    end
     button.widgets.incomingHeal = incomingHeal
-    incomingHeal:SetTexture(Cell.vars.texture)
     incomingHeal:Hide()
-    incomingHeal.SetValue = DumbFunc
 
     --* indicatorFrame
     local indicatorFrame = CreateFrame("Frame", name.."IndicatorFrame", button)
@@ -3849,19 +4199,48 @@ function CellUnitButton_OnLoad(button)
     midLevelFrame:SetAllPoints(healthBar)
 
     -- shield bar
-    local shieldBar = midLevelFrame:CreateTexture(name.."ShieldBar", "ARTWORK", nil, -5)
+    local shieldBar
+    if Cell.isMidnight then
+        -- Midnight: StatusBar so native SetMinMaxValues/SetValue work with secret values
+        shieldBar = CreateFrame("StatusBar", name.."ShieldBar", midLevelFrame)
+        shieldBar:SetStatusBarTexture("Interface\\AddOns\\Cell\\Media\\shield")
+        shieldBar:GetStatusBarTexture():SetDrawLayer("ARTWORK", -5)
+        shieldBar:SetFrameLevel(midLevelFrame:GetFrameLevel()+1)
+        shieldBar:SetAllPoints(healthBar)
+        -- Compatibility shims: map Texture methods to StatusBar equivalents
+        shieldBar.SetVertexColor = shieldBar.SetStatusBarColor
+        shieldBar.SetTexture = shieldBar.SetStatusBarTexture
+    else
+        -- Pre-Midnight: Texture with manual width/height positioning
+        shieldBar = midLevelFrame:CreateTexture(name.."ShieldBar", "ARTWORK", nil, -5)
+        shieldBar:SetTexture("Interface\\AddOns\\Cell\\Media\\shield", "REPEAT", "REPEAT")
+        shieldBar:SetHorizTile(true)
+        shieldBar:SetVertTile(true)
+        shieldBar.SetValue = DumbFunc
+    end
     button.widgets.shieldBar = shieldBar
-    shieldBar:SetTexture("Interface\\AddOns\\Cell\\Media\\shield", "REPEAT", "REPEAT")
-    shieldBar:SetHorizTile(true)
-    shieldBar:SetVertTile(true)
     shieldBar:Hide()
-    shieldBar.SetValue = DumbFunc
 
-    local shieldBarR = midLevelFrame:CreateTexture(name.."ShieldBarR", "ARTWORK", nil, -5)
+    local shieldBarR
+    if Cell.isMidnight then
+        -- Midnight: StatusBar for reverse-fill shield display with secret values
+        shieldBarR = CreateFrame("StatusBar", name.."ShieldBarR", midLevelFrame)
+        shieldBarR:SetStatusBarTexture("Interface\\AddOns\\Cell\\Media\\shield")
+        shieldBarR:GetStatusBarTexture():SetDrawLayer("ARTWORK", -5)
+        shieldBarR:SetFrameLevel(midLevelFrame:GetFrameLevel()+1)
+        shieldBarR:SetAllPoints(healthBar)
+        shieldBarR:SetReverseFill(true)
+        -- Compatibility shims: map Texture methods to StatusBar equivalents
+        shieldBarR.SetVertexColor = shieldBarR.SetStatusBarColor
+        shieldBarR.SetTexture = shieldBarR.SetStatusBarTexture
+    else
+        -- Pre-Midnight: Texture with manual width/height positioning
+        shieldBarR = midLevelFrame:CreateTexture(name.."ShieldBarR", "ARTWORK", nil, -5)
+        shieldBarR:SetTexture("Interface\\AddOns\\Cell\\Media\\shield", "REPEAT", "REPEAT")
+        shieldBarR:SetHorizTile(true)
+        shieldBarR:SetVertTile(true)
+    end
     button.widgets.shieldBarR = shieldBarR
-    shieldBarR:SetTexture("Interface\\AddOns\\Cell\\Media\\shield", "REPEAT", "REPEAT")
-    shieldBarR:SetHorizTile(true)
-    shieldBarR:SetVertTile(true)
     shieldBarR:Hide()
     shieldBar.shieldBarR = shieldBarR
 
@@ -3889,17 +4268,49 @@ function CellUnitButton_OnLoad(button)
     overAbsorbGlow:Hide()
 
     -- absorbs bar
-    local absorbsBar = midLevelFrame:CreateTexture(name.."AbsorbsBar", "ARTWORK", nil, 1)
+    local absorbsBar
+    if Cell.isMidnight then
+        -- Midnight: StatusBar so native SetMinMaxValues/SetValue work with secret values
+        absorbsBar = CreateFrame("StatusBar", name.."AbsorbsBar", midLevelFrame)
+        absorbsBar:SetStatusBarTexture("Interface\\AddOns\\Cell\\Media\\shield.tga")
+        absorbsBar:GetStatusBarTexture():SetDrawLayer("ARTWORK", 1)
+        absorbsBar:SetStatusBarColor(1, 0.1, 0.1, 1)
+        absorbsBar:SetFrameLevel(midLevelFrame:GetFrameLevel()+2)
+        absorbsBar:SetAllPoints(healthBar)
+        absorbsBar:SetReverseFill(true)
+        -- Compatibility shims: map Texture methods to StatusBar equivalents
+        absorbsBar.SetVertexColor = absorbsBar.SetStatusBarColor
+        absorbsBar.SetTexture = absorbsBar.SetStatusBarTexture
+    else
+        -- Pre-Midnight: Texture with manual width/height positioning
+        absorbsBar = midLevelFrame:CreateTexture(name.."AbsorbsBar", "ARTWORK", nil, 1)
+        absorbsBar:SetTexture("Interface\\AddOns\\Cell\\Media\\shield.tga", "REPEAT", "REPEAT")
+        absorbsBar:SetHorizTile(true)
+        absorbsBar:SetVertTile(true)
+        absorbsBar:SetVertexColor(1, 0.1, 0.1, 1)
+        absorbsBar.SetValue = DumbFunc
+    end
     button.widgets.absorbsBar = absorbsBar
     absorbsBar.healthBar = healthBar
-    absorbsBar:SetTexture("Interface\\AddOns\\Cell\\Media\\shield.tga", "REPEAT", "REPEAT")
-    absorbsBar:SetHorizTile(true)
-    absorbsBar:SetVertTile(true)
-    absorbsBar:SetVertexColor(1, 0.1, 0.1, 1)
     -- absorbsBar:SetBlendMode("ADD")
     absorbsBar:Hide()
-    absorbsBar.SetValue = DumbFunc
     absorbsBar.overAbsorbGlow = overAbsorbGlow
+
+    -- Midnight: Overlay StatusBars need initial min/max for SetValue to work before UpdateHealthMax fires
+    if Cell.isMidnight then
+        if button.widgets.incomingHeal then
+            button.widgets.incomingHeal:SetMinMaxValues(0, 1)
+        end
+        if button.widgets.shieldBar then
+            button.widgets.shieldBar:SetMinMaxValues(0, 1)
+        end
+        if button.widgets.shieldBarR then
+            button.widgets.shieldBarR:SetMinMaxValues(0, 1)
+        end
+        if button.widgets.absorbsBar then
+            button.widgets.absorbsBar:SetMinMaxValues(0, 1)
+        end
+    end
 
     -- bar animation
     -- flash

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1166,8 +1166,15 @@ local function HandleDebuff(self, auraInfo)
     local count = auraInfo.applications
     local debuffType = auraInfo.dispelName or ""
     local expirationTime = auraInfo.expirationTime or 0
-    local start = expirationTime - auraInfo.duration
     local duration = auraInfo.duration
+    -- Midnight 12.0.0+: expirationTime and duration may be secret — skip arithmetic entirely
+    local start
+    if Cell.isMidnight then
+        start = 0
+        duration = 0
+    else
+        start = expirationTime - duration
+    end
     local source = auraInfo.sourceUnit
     local spellId = auraInfo.spellId
     -- local attribute = auraInfo.points[1] -- UnitAura:arg16
@@ -1454,8 +1461,15 @@ local function HandleBuff(self, auraInfo)
     local count = auraInfo.applications
     -- local debuffType = auraInfo.isHarmful and auraInfo.dispelName
     local expirationTime = auraInfo.expirationTime or 0
-    local start = expirationTime - auraInfo.duration
     local duration = auraInfo.duration
+    -- Midnight 12.0.0+: expirationTime and duration may be secret — skip arithmetic entirely
+    local start
+    if Cell.isMidnight then
+        start = 0
+        duration = 0
+    else
+        start = expirationTime - duration
+    end
     local source = auraInfo.sourceUnit
     local spellId = auraInfo.spellId
     -- local attribute = auraInfo.points[1] -- UnitAura:arg16
@@ -1706,7 +1720,16 @@ UnitButton_UpdateAuras = function(self, updateInfo)
         UnitButton_UpdateBuffs(self, true)
         UnitButton_UpdateDebuffs(self, true)
     else
-        -- partial update
+        -- Midnight 12.0.0+: aura fields (isHelpful, isHarmful, expirationTime, etc.) may be
+        -- secret at any time during combat/instances. F.IsAuraRestricted() is unreliable.
+        -- Always force full update on Midnight to avoid secret boolean/arithmetic errors.
+        if Cell.isMidnight then
+            UnitButton_UpdateBuffs(self, true)
+            UnitButton_UpdateDebuffs(self, true)
+            I.UpdateStatusIcon(self)
+            return
+        end
+
         local buffsChanged, debuffsChanged
         wipe(self._missing_auras)
 
@@ -1909,7 +1932,10 @@ local function UnitButton_UpdatePowerStates(self)
 
     self.states.power = UnitPower(unit)
     self.states.powerMax = UnitPowerMax(unit)
-    if self.states.powerMax <= 0 then self.states.powerMax = 1 end
+    -- Midnight 12.0.0+: UnitPowerMax may return a secret number during restricted contexts
+    if not (Cell.isMidnight and F.IsAuraRestricted()) then
+        if self.states.powerMax <= 0 then self.states.powerMax = 1 end
+    end
 end
 
 -------------------------------------------------
@@ -2111,7 +2137,8 @@ UnitButton_UpdateRole = function(self)
         roleIcon:SetRole(role)
 
         --! check vehicle root
-        if self.states.guid and strfind(self.states.guid, "^Vehicle") and not UnitInPartyIsAI(unit) then
+        -- Midnight 12.0.0+: guid may be secret for NPC/boss units
+        if self.states.guid and not (issecretvalue and issecretvalue(self.states.guid)) and strfind(self.states.guid, "^Vehicle") and not UnitInPartyIsAI(unit) then
             CheckVehicleRoot(self, unit)
         end
     else
@@ -2639,6 +2666,9 @@ local function UnitButton_UpdateInRange(self, ir)
     if not unit then return end
 
     local inRange = IsInRange(unit)
+    -- Nil-safety: if IsInRange errors (e.g. secret value issue), default to true
+    -- so frames don't grey out incorrectly
+    if inRange == nil then inRange = true end
 
     self.states.inRange = inRange
     if Cell.loaded then
@@ -2710,7 +2740,8 @@ UnitButton_UpdateStatusText = function(self)
         statusText:Show()
         statusText:SetStatus("OFFLINE")
         statusText:ShowTimer()
-    elseif UnitIsAFK(unit) then
+    -- Midnight 12.0.0+: UnitIsAFK may return a secret boolean — skip on Midnight
+    elseif not Cell.isMidnight and UnitIsAFK(unit) then
         statusText:Show()
         statusText:SetStatus("AFK")
         statusText:ShowTimer()

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1172,7 +1172,8 @@ local function HandleDebuff(self, auraInfo)
     -- SetTexture() accepts secret numbers, so this works as-is
     local icon = auraInfo.icon
     local count = auraInfo.applications
-    local debuffType = auraInfo.dispelName or ""
+    -- Midnight 12.0.0+: dispelName may be secret (truthy, so `or ""` won't help); sanitize it
+    local debuffType = (auraInfo.dispelName and (not issecretvalue or not issecretvalue(auraInfo.dispelName))) and auraInfo.dispelName or ""
     local expirationTime = auraInfo.expirationTime or 0
     local duration = auraInfo.duration
     -- Midnight 12.0.0+: expirationTime and duration may be secret even when spellId is not.
@@ -1340,7 +1341,7 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
                     self.indicators.raidDebuffs[i]:SetCooldown(
                         rdStart,
                         rdDur,
-                        auraInfo.dispelName or "",
+                        (auraInfo.dispelName and (not issecretvalue or not issecretvalue(auraInfo.dispelName))) and auraInfo.dispelName or "",
                         auraInfo.icon,
                         auraInfo.applications,
                         auraInfo.refreshing,
@@ -1415,7 +1416,7 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
                     bStart = 0
                     bDur = 0
                 end
-                self.indicators.debuffs[startIndex]:SetCooldown(bStart, bDur, auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing, true)
+                self.indicators.debuffs[startIndex]:SetCooldown(bStart, bDur, (auraInfo.dispelName and (not issecretvalue or not issecretvalue(auraInfo.dispelName))) and auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing, true)
                 self.indicators.debuffs[startIndex].auraInstanceID = auraInstanceID -- NOTE: for tooltip
                 self.indicators.debuffs[startIndex].spellId = auraInfo.spellId -- NOTE: for blacklist
                 startIndex = startIndex + 1
@@ -1436,7 +1437,7 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
                     nStart = 0
                     nDur = 0
                 end
-                self.indicators.debuffs[startIndex]:SetCooldown(nStart, nDur, auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing)
+                self.indicators.debuffs[startIndex]:SetCooldown(nStart, nDur, (auraInfo.dispelName and (not issecretvalue or not issecretvalue(auraInfo.dispelName))) and auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing)
                 self.indicators.debuffs[startIndex].auraInstanceID = auraInstanceID -- NOTE: for tooltip
                 self.indicators.debuffs[startIndex].spellId = auraInfo.spellId -- NOTE: for blacklist
                 startIndex = startIndex + 1

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1111,8 +1111,13 @@ end
 local function UpdateAuraRefreshState(auraInfo)
     if Cell.vars.iconAnimation == "duration" then
         local timeIncreased, countIncreased
-        if Cell.isMidnight and not F.IsAuraNonSecret(auraInfo) then
-            -- Secret aura: can't do arithmetic/comparison on secret expirationTime or applications (Midnight 12.0.0+)
+        if Cell.isMidnight and (
+            not F.IsValueNonSecret(auraInfo.expirationTime)
+            or not F.IsValueNonSecret(auraInfo.oldExpirationTime)
+            or not F.IsValueNonSecret(auraInfo.applications)
+            or not F.IsValueNonSecret(auraInfo.oldApplications)
+        ) then
+            -- One or more fields are secret: can't do arithmetic/comparison (Midnight 12.0.0+)
             timeIncreased = false
             countIncreased = false
         else
@@ -1121,8 +1126,11 @@ local function UpdateAuraRefreshState(auraInfo)
         end
         auraInfo.refreshing = timeIncreased or countIncreased
     elseif Cell.vars.iconAnimation == "stack" then
-        if Cell.isMidnight and not F.IsAuraNonSecret(auraInfo) then
-            -- Secret aura: can't compare secret applications value (Midnight 12.0.0+)
+        if Cell.isMidnight and (
+            not F.IsValueNonSecret(auraInfo.applications)
+            or not F.IsValueNonSecret(auraInfo.oldApplications)
+        ) then
+            -- Secret applications: can't compare (Midnight 12.0.0+)
             auraInfo.refreshing = false
         else
             auraInfo.refreshing = auraInfo.oldApplications and (auraInfo.applications > auraInfo.oldApplications) or false
@@ -1167,10 +1175,10 @@ local function HandleDebuff(self, auraInfo)
     local debuffType = auraInfo.dispelName or ""
     local expirationTime = auraInfo.expirationTime or 0
     local duration = auraInfo.duration
-    -- Midnight 12.0.0+: expirationTime and duration may be secret for some auras.
-    -- Use per-aura check: non-secret auras get proper duration/cooldown display.
+    -- Midnight 12.0.0+: expirationTime and duration may be secret even when spellId is not.
+    -- Guard per-field: non-secret temporal fields get proper duration/cooldown display.
     local start
-    if F.IsAuraNonSecret(auraInfo) then
+    if F.IsValueNonSecret(expirationTime) and F.IsValueNonSecret(duration) then
         start = expirationTime - duration
     else
         start = 0
@@ -1320,9 +1328,17 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
             local auraInstanceID = self._debuffs_raid[i]
             if auraInstanceID then
                 local auraInfo = self._debuffs_cache[auraInstanceID]
+                local rdStart, rdDur
+                if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
+                    rdStart = (auraInfo.expirationTime or 0) - auraInfo.duration
+                    rdDur = auraInfo.duration
+                else
+                    rdStart = 0
+                    rdDur = 0
+                end
                 self.indicators.raidDebuffs[i]:SetCooldown(
-                    (auraInfo.expirationTime or 0) - auraInfo.duration,
-                    auraInfo.duration,
+                    rdStart,
+                    rdDur,
                     auraInfo.dispelName or "",
                     auraInfo.icon,
                     auraInfo.applications,
@@ -1389,7 +1405,15 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
             local auraInfo = self._debuffs_cache[auraInstanceID]
             if startIndex <= indicatorNums["debuffs"] then
                 -- start, duration, debuffType, texture, count
-                self.indicators.debuffs[startIndex]:SetCooldown((auraInfo.expirationTime or 0) - auraInfo.duration, auraInfo.duration, auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing, true)
+                local bStart, bDur
+                if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
+                    bStart = (auraInfo.expirationTime or 0) - auraInfo.duration
+                    bDur = auraInfo.duration
+                else
+                    bStart = 0
+                    bDur = 0
+                end
+                self.indicators.debuffs[startIndex]:SetCooldown(bStart, bDur, auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing, true)
                 self.indicators.debuffs[startIndex].auraInstanceID = auraInstanceID -- NOTE: for tooltip
                 self.indicators.debuffs[startIndex].spellId = auraInfo.spellId -- NOTE: for blacklist
                 startIndex = startIndex + 1
@@ -1402,7 +1426,15 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
             local auraInfo = self._debuffs_cache[auraInstanceID]
             if startIndex <= indicatorNums["debuffs"] then
                 -- start, duration, debuffType, texture, count
-                self.indicators.debuffs[startIndex]:SetCooldown((auraInfo.expirationTime or 0) - auraInfo.duration, auraInfo.duration, auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing)
+                local nStart, nDur
+                if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
+                    nStart = (auraInfo.expirationTime or 0) - auraInfo.duration
+                    nDur = auraInfo.duration
+                else
+                    nStart = 0
+                    nDur = 0
+                end
+                self.indicators.debuffs[startIndex]:SetCooldown(nStart, nDur, auraInfo.dispelName or "", auraInfo.icon, auraInfo.applications, auraInfo.refreshing)
                 self.indicators.debuffs[startIndex].auraInstanceID = auraInstanceID -- NOTE: for tooltip
                 self.indicators.debuffs[startIndex].spellId = auraInfo.spellId -- NOTE: for blacklist
                 startIndex = startIndex + 1
@@ -1461,10 +1493,10 @@ local function HandleBuff(self, auraInfo)
     -- local debuffType = auraInfo.isHarmful and auraInfo.dispelName
     local expirationTime = auraInfo.expirationTime or 0
     local duration = auraInfo.duration
-    -- Midnight 12.0.0+: expirationTime and duration may be secret for some auras.
-    -- Use per-aura check: non-secret auras get proper duration/cooldown display.
+    -- Midnight 12.0.0+: expirationTime and duration may be secret even when spellId is not.
+    -- Guard per-field: non-secret temporal fields get proper duration/cooldown display.
     local start
-    if F.IsAuraNonSecret(auraInfo) then
+    if F.IsValueNonSecret(expirationTime) and F.IsValueNonSecret(duration) then
         start = expirationTime - duration
     else
         start = 0
@@ -1757,8 +1789,11 @@ UnitButton_UpdateAuras = function(self, updateInfo)
                     aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
                     if aura then
                         if F.IsAuraNonSecret(aura) then
-                            aura.oldExpirationTime = self._buffs_cache[auraInstanceID].expirationTime or 0
-                            aura.oldApplications = self._buffs_cache[auraInstanceID].applications
+                            -- Sanitize cached values: they may be secret even if new aura's spellId is not
+                            local cachedExp = self._buffs_cache[auraInstanceID].expirationTime
+                            local cachedApp = self._buffs_cache[auraInstanceID].applications
+                            aura.oldExpirationTime = (cachedExp and F.IsValueNonSecret(cachedExp)) and cachedExp or 0
+                            aura.oldApplications = (cachedApp and F.IsValueNonSecret(cachedApp)) and cachedApp or nil
                         end
                         self._buffs_cache[auraInstanceID] = aura
                     end
@@ -1767,8 +1802,11 @@ UnitButton_UpdateAuras = function(self, updateInfo)
                     aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
                     if aura then
                         if F.IsAuraNonSecret(aura) then
-                            aura.oldExpirationTime = self._debuffs_cache[auraInstanceID].expirationTime or 0
-                            aura.oldApplications = self._debuffs_cache[auraInstanceID].applications
+                            -- Sanitize cached values: they may be secret even if new aura's spellId is not
+                            local cachedExp = self._debuffs_cache[auraInstanceID].expirationTime
+                            local cachedApp = self._debuffs_cache[auraInstanceID].applications
+                            aura.oldExpirationTime = (cachedExp and F.IsValueNonSecret(cachedExp)) and cachedExp or 0
+                            aura.oldApplications = (cachedApp and F.IsValueNonSecret(cachedApp)) and cachedApp or nil
                         end
                         self._debuffs_cache[auraInstanceID] = aura
                     end

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1328,31 +1328,33 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
             local auraInstanceID = self._debuffs_raid[i]
             if auraInstanceID then
                 local auraInfo = self._debuffs_cache[auraInstanceID]
-                local rdStart, rdDur
-                if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
-                    rdStart = (auraInfo.expirationTime or 0) - auraInfo.duration
-                    rdDur = auraInfo.duration
-                else
-                    rdStart = 0
-                    rdDur = 0
-                end
-                self.indicators.raidDebuffs[i]:SetCooldown(
-                    rdStart,
-                    rdDur,
-                    auraInfo.dispelName or "",
-                    auraInfo.icon,
-                    auraInfo.applications,
-                    auraInfo.refreshing,
-                    I.IsDebuffUseElapsedTime(auraInfo.name, auraInfo.spellId)
-                )
-                self.indicators.raidDebuffs[i].auraInstanceID = auraInstanceID -- NOTE: for tooltip
-                startIndex = startIndex + 1
-                -- remove from debuffs
-                self._debuffs_big[auraInstanceID] = nil
-                self._debuffs_normal[auraInstanceID] = nil
+                if auraInfo then
+                    local rdStart, rdDur
+                    if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
+                        rdStart = (auraInfo.expirationTime or 0) - auraInfo.duration
+                        rdDur = auraInfo.duration
+                    else
+                        rdStart = 0
+                        rdDur = 0
+                    end
+                    self.indicators.raidDebuffs[i]:SetCooldown(
+                        rdStart,
+                        rdDur,
+                        auraInfo.dispelName or "",
+                        auraInfo.icon,
+                        auraInfo.applications,
+                        auraInfo.refreshing,
+                        I.IsDebuffUseElapsedTime(auraInfo.name, auraInfo.spellId)
+                    )
+                    self.indicators.raidDebuffs[i].auraInstanceID = auraInstanceID -- NOTE: for tooltip
+                    startIndex = startIndex + 1
+                    -- remove from debuffs
+                    self._debuffs_big[auraInstanceID] = nil
+                    self._debuffs_normal[auraInstanceID] = nil
 
-                if i == 1 then -- top
-                    topAuraInstanceID = auraInstanceID
+                    if i == 1 then -- top
+                        topAuraInstanceID = auraInstanceID
+                    end
                 end
             end
         end
@@ -1403,7 +1405,7 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
         -- bigDebuffs first
         for auraInstanceID in next, self._debuffs_big do
             local auraInfo = self._debuffs_cache[auraInstanceID]
-            if startIndex <= indicatorNums["debuffs"] then
+            if auraInfo and startIndex <= indicatorNums["debuffs"] then
                 -- start, duration, debuffType, texture, count
                 local bStart, bDur
                 if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
@@ -1417,14 +1419,14 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
                 self.indicators.debuffs[startIndex].auraInstanceID = auraInstanceID -- NOTE: for tooltip
                 self.indicators.debuffs[startIndex].spellId = auraInfo.spellId -- NOTE: for blacklist
                 startIndex = startIndex + 1
-            else
+            elseif startIndex > indicatorNums["debuffs"] then
                 break
             end
         end
         -- then normal debuffs
         for auraInstanceID in next, self._debuffs_normal do
             local auraInfo = self._debuffs_cache[auraInstanceID]
-            if startIndex <= indicatorNums["debuffs"] then
+            if auraInfo and startIndex <= indicatorNums["debuffs"] then
                 -- start, duration, debuffType, texture, count
                 local nStart, nDur
                 if F.IsValueNonSecret(auraInfo.expirationTime) and F.IsValueNonSecret(auraInfo.duration) then
@@ -1438,7 +1440,7 @@ local function UnitButton_UpdateDebuffs(self, isFullUpdate)
                 self.indicators.debuffs[startIndex].auraInstanceID = auraInstanceID -- NOTE: for tooltip
                 self.indicators.debuffs[startIndex].spellId = auraInfo.spellId -- NOTE: for blacklist
                 startIndex = startIndex + 1
-            else
+            elseif startIndex > indicatorNums["debuffs"] then
                 break
             end
         end

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -77,14 +77,14 @@ local shieldEnabled, overshieldEnabled, overshieldReverseFillEnabled
 local absorbEnabled, absorbInvertColor
 
 -- Midnight: Curve for CELL_FADE_OUT_HEALTH_PERCENT feature
--- Maps health percent → alpha so we can evaluate secret health% without comparisons
+-- Maps health percent â†’ alpha so we can evaluate secret health% without comparisons
 local fadeOutHealthCurve
 local fadeOutHealthCurve_threshold -- track last threshold to know when to rebuild
 local fadeOutHealthCurve_alpha -- track last outOfRangeAlpha to know when to rebuild
 
 -- Builds/rebuilds the fade-out health curve when threshold or alpha changes.
--- health% < threshold → alpha 1.0 (fully visible, needs healing)
--- health% >= threshold → outOfRangeAlpha (faded out, healthy enough)
+-- health% < threshold â†’ alpha 1.0 (fully visible, needs healing)
+-- health% >= threshold â†’ outOfRangeAlpha (faded out, healthy enough)
 local function RebuildFadeOutHealthCurve()
     if not Cell.isMidnight or not C_CurveUtil then return end
     local threshold = CELL_FADE_OUT_HEALTH_PERCENT
@@ -1111,8 +1111,8 @@ end
 local function UpdateAuraRefreshState(auraInfo)
     if Cell.vars.iconAnimation == "duration" then
         local timeIncreased, countIncreased
-        if Cell.isMidnight then
-            -- Can't do arithmetic/comparison on secret expirationTime or applications (Midnight 12.0.0+)
+        if Cell.isMidnight and not F.IsAuraNonSecret(auraInfo) then
+            -- Secret aura: can't do arithmetic/comparison on secret expirationTime or applications (Midnight 12.0.0+)
             timeIncreased = false
             countIncreased = false
         else
@@ -1121,8 +1121,8 @@ local function UpdateAuraRefreshState(auraInfo)
         end
         auraInfo.refreshing = timeIncreased or countIncreased
     elseif Cell.vars.iconAnimation == "stack" then
-        if Cell.isMidnight then
-            -- Can't compare secret applications value (Midnight 12.0.0+)
+        if Cell.isMidnight and not F.IsAuraNonSecret(auraInfo) then
+            -- Secret aura: can't compare secret applications value (Midnight 12.0.0+)
             auraInfo.refreshing = false
         else
             auraInfo.refreshing = auraInfo.oldApplications and (auraInfo.applications > auraInfo.oldApplications) or false
@@ -1167,13 +1167,14 @@ local function HandleDebuff(self, auraInfo)
     local debuffType = auraInfo.dispelName or ""
     local expirationTime = auraInfo.expirationTime or 0
     local duration = auraInfo.duration
-    -- Midnight 12.0.0+: expirationTime and duration may be secret — skip arithmetic entirely
+    -- Midnight 12.0.0+: expirationTime and duration may be secret for some auras.
+    -- Use per-aura check: non-secret auras get proper duration/cooldown display.
     local start
-    if Cell.isMidnight then
+    if F.IsAuraNonSecret(auraInfo) then
+        start = expirationTime - duration
+    else
         start = 0
         duration = 0
-    else
-        start = expirationTime - duration
     end
     local source = auraInfo.sourceUnit
     local spellId = auraInfo.spellId
@@ -1189,12 +1190,10 @@ local function HandleDebuff(self, auraInfo)
         UpdateAuraRefreshState(auraInfo)
         self._debuffs_cache[auraInstanceID] = auraInfo
 
-        -- On Midnight in restricted context, spellId may be secret — can't use as table key
-        -- Use F.IsAuraRestricted() to choose code path at runtime
         local isBig = false
         local isBlacklisted = false
         local isDispelBlacklisted = false
-        if not Cell.isMidnight or not F.IsAuraRestricted() then
+        if F.IsAuraNonSecret(auraInfo) then
             isBig = spellId and Cell.vars.bigDebuffs[spellId] or false
             isBlacklisted = spellId and Cell.vars.debuffBlacklist[spellId] or false
             isDispelBlacklisted = spellId and Cell.vars.dispelBlacklist[spellId] or false
@@ -1253,9 +1252,9 @@ local function HandleDebuff(self, auraInfo)
             self._debuffs_normal[auraInstanceID] = nil
         end
 
-        -- On Midnight in restricted context, spellId may be secret — can't use in equality comparisons
-        if not Cell.isMidnight or not F.IsAuraRestricted() then
-            -- resurrections: 图腾复生/复生
+        -- Per-aura check: only compare spellId if non-secret
+        if F.IsAuraNonSecret(auraInfo) then
+            -- resurrections: å›¾è…¾å¤ç”Ÿ/å¤ç”Ÿ
             if spellId == 255234 or spellId == 225080 then
                 -- NOTE: this rez lasts longer than the debuff
                 self._debuffs.resurrectionFound = true
@@ -1462,13 +1461,14 @@ local function HandleBuff(self, auraInfo)
     -- local debuffType = auraInfo.isHarmful and auraInfo.dispelName
     local expirationTime = auraInfo.expirationTime or 0
     local duration = auraInfo.duration
-    -- Midnight 12.0.0+: expirationTime and duration may be secret — skip arithmetic entirely
+    -- Midnight 12.0.0+: expirationTime and duration may be secret for some auras.
+    -- Use per-aura check: non-secret auras get proper duration/cooldown display.
     local start
-    if Cell.isMidnight then
+    if F.IsAuraNonSecret(auraInfo) then
+        start = expirationTime - duration
+    else
         start = 0
         duration = 0
-    else
-        start = expirationTime - duration
     end
     local source = auraInfo.sourceUnit
     local spellId = auraInfo.spellId
@@ -1519,8 +1519,8 @@ local function HandleBuff(self, auraInfo)
         -- user created indicators
         I.UpdateCustomIndicators(self, auraInfo)
 
-        -- On Midnight in restricted context, spellId may be secret — can't use in equality comparisons
-        if not Cell.isMidnight or not F.IsAuraRestricted() then
+        -- Per-aura check: only compare spellId if non-secret
+        if F.IsAuraNonSecret(auraInfo) then
             -- check BG flags for statusIcon
             if spellId == 156621 then
                 self.states.BGFlag = "alliance"
@@ -1654,9 +1654,9 @@ local function UpdateMirrorImage(b, event)
 end
 
 local SelfBarriers = {
-    [11426] = true, -- 寒冰护体 (self)
-    [235313] = true, -- 烈焰护体 (self)
-    [235450] = true, -- 棱光护体 (self)
+    [11426] = true, -- å¯’å†°æŠ¤ä½“ (self)
+    [235313] = true, -- çƒˆç„°æŠ¤ä½“ (self)
+    [235450] = true, -- æ£±å…‰æŠ¤ä½“ (self)
 }
 
 local function UpdateMassBarrier(b, event)
@@ -1720,28 +1720,30 @@ UnitButton_UpdateAuras = function(self, updateInfo)
         UnitButton_UpdateBuffs(self, true)
         UnitButton_UpdateDebuffs(self, true)
     else
-        -- Midnight 12.0.0+: aura fields (isHelpful, isHarmful, expirationTime, etc.) may be
-        -- secret at any time during combat/instances. F.IsAuraRestricted() is unreliable.
-        -- Always force full update on Midnight to avoid secret boolean/arithmetic errors.
-        if Cell.isMidnight then
-            UnitButton_UpdateBuffs(self, true)
-            UnitButton_UpdateDebuffs(self, true)
-            I.UpdateStatusIcon(self)
-            return
-        end
-
+        -- Midnight 12.0.0+: some aura fields may still be secret. Per-aura checks in
+        -- HandleBuff/HandleDebuff handle this. We no longer force full update for ALL
+        -- Midnight aura events â€” only fall back to full update if we encounter secret
+        -- isHelpful/isHarmful fields in addedAuras that prevent classification.
         local buffsChanged, debuffsChanged
         wipe(self._missing_auras)
 
         if updateInfo.addedAuras then
             for _, aura in next, updateInfo.addedAuras do
-                if aura.isHelpful then
-                    buffsChanged = true
-                    self._buffs_cache[aura.auraInstanceID] = aura
-                end
-                if aura.isHarmful then
-                    debuffsChanged = true
-                    self._debuffs_cache[aura.auraInstanceID] = aura
+                if F.IsAuraNonSecret(aura) then
+                    if aura.isHelpful then
+                        buffsChanged = true
+                        self._buffs_cache[aura.auraInstanceID] = aura
+                    end
+                    if aura.isHarmful then
+                        debuffsChanged = true
+                        self._debuffs_cache[aura.auraInstanceID] = aura
+                    end
+                else
+                    -- Secret aura: can't classify as buff/debuff; force full update
+                    UnitButton_UpdateBuffs(self, true)
+                    UnitButton_UpdateDebuffs(self, true)
+                    I.UpdateStatusIcon(self)
+                    return
                 end
             end
         end
@@ -1750,51 +1752,30 @@ UnitButton_UpdateAuras = function(self, updateInfo)
             local aura
             -- auraInstanceID is NOT secret and is safe to use as table key
             for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
-                if Cell.isMidnight then
-                    -- On Midnight, GetAuraDataByAuraInstanceID may be blocked when auras are restricted,
-                    -- and aura fields (expirationTime, applications) are secret — skip refresh detection
-                    if self._buffs_cache[auraInstanceID] then
-                        buffsChanged = true
-                        if not F.IsAuraRestricted() then
-                            -- GetAuraDataByAuraInstanceID is blocked when aura access is restricted
-                            aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                            if aura then
-                                self._buffs_cache[auraInstanceID] = aura
-                            end
-                        end
-                    elseif self._debuffs_cache[auraInstanceID] then
-                        debuffsChanged = true
-                        if not F.IsAuraRestricted() then
-                            aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                            if aura then
-                                self._debuffs_cache[auraInstanceID] = aura
-                            end
-                        end
-                    else
-                        if not F.IsAuraRestricted() then
-                            self._missing_auras[auraInstanceID] = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                        end
-                    end
-                else
-                    -- Pre-Midnight: original logic with expirationTime/applications comparisons
-                    if self._buffs_cache[auraInstanceID] then
-                        buffsChanged = true
-                        aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                        if aura then
+                if self._buffs_cache[auraInstanceID] then
+                    buffsChanged = true
+                    aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                    if aura then
+                        if F.IsAuraNonSecret(aura) then
                             aura.oldExpirationTime = self._buffs_cache[auraInstanceID].expirationTime or 0
                             aura.oldApplications = self._buffs_cache[auraInstanceID].applications
-                            self._buffs_cache[auraInstanceID] = aura
                         end
-                    elseif self._debuffs_cache[auraInstanceID] then
-                        debuffsChanged = true
-                        aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
-                        if aura then
+                        self._buffs_cache[auraInstanceID] = aura
+                    end
+                elseif self._debuffs_cache[auraInstanceID] then
+                    debuffsChanged = true
+                    aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                    if aura then
+                        if F.IsAuraNonSecret(aura) then
                             aura.oldExpirationTime = self._debuffs_cache[auraInstanceID].expirationTime or 0
                             aura.oldApplications = self._debuffs_cache[auraInstanceID].applications
-                            self._debuffs_cache[auraInstanceID] = aura
                         end
-                    else
-                        self._missing_auras[auraInstanceID] = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                        self._debuffs_cache[auraInstanceID] = aura
+                    end
+                else
+                    aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+                    if aura then
+                        self._missing_auras[auraInstanceID] = aura
                     end
                 end
             end
@@ -1816,13 +1797,17 @@ UnitButton_UpdateAuras = function(self, updateInfo)
 
         if next(self._missing_auras) then
             for _, aura in next, self._missing_auras do
-                if aura.isHelpful then
-                    buffsChanged = true
-                    self._buffs_cache[aura.auraInstanceID] = aura
-                elseif aura.isHarmful then
-                    debuffsChanged = true
-                    self._debuffs_cache[aura.auraInstanceID] = aura
+                if F.IsAuraNonSecret(aura) then
+                    if aura.isHelpful then
+                        buffsChanged = true
+                        self._buffs_cache[aura.auraInstanceID] = aura
+                    elseif aura.isHarmful then
+                        debuffsChanged = true
+                        self._debuffs_cache[aura.auraInstanceID] = aura
+                    end
                 end
+                -- Secret missing auras are silently dropped â€” they'll be
+                -- picked up on the next full update if needed
             end
         end
 
@@ -1846,8 +1831,19 @@ local function UnitButton_UpdateHealthStates(self, diff)
     local unit = self.states.displayedUnit
 
     if Cell.isMidnight and self.widgets.healthCalculator then
-        -- MIDNIGHT PATH: use calculator — no arithmetic on secrets
+        -- MIDNIGHT PATH: use calculator â€" no arithmetic on secrets
         UnitButton_UpdateCalculator(self)
+        -- Store healthPercent for color logic.
+        -- GetCurrentHealthPercent() returns a secret value inside PvP instances —
+        -- Lua comparisons on secrets throw errors. Use it only when non-secret.
+        local hpPct = self.widgets.healthCalculator:GetCurrentHealthPercent()
+        if F.IsValueNonSecret(hpPct) then
+            self.states.healthPercent = hpPct
+        else
+            -- Secret: default to 0 so F.GetHealthBarColor won't trigger fullColor (which checks == 1).
+            -- class_color / class_color_dark modes don't use percent, so they still work.
+            self.states.healthPercent = 0
+        end
         -- Death detection uses non-secret boolean
         self.states.wasDead = self.states.isDead
         self.states.isDead = UnitIsDeadOrGhost(unit) or false
@@ -2244,8 +2240,8 @@ UnitButton_UpdatePowerText = function(self)
 
     if self.states.powerMax and self.states.power and not self.states.isDeadOrGhost then
         -- On Midnight, power and powerMax may be secret values (Midnight 12.0.0+)
-        -- SetValue uses string.format/AbbreviateNumbers which accept secrets → FontString:SetText accepts secrets
-        -- Secret handling is in the powerText indicator's SetValue method (Indicators/Base.lua) — Phase 8 follow-up
+        -- SetValue uses string.format/AbbreviateNumbers which accept secrets â†’ FontString:SetText accepts secrets
+        -- Secret handling is in the powerText indicator's SetValue method (Indicators/Base.lua) â€” Phase 8 follow-up
         self.indicators.powerText:SetValue(self.states.power, self.states.powerMax)
     else
         self.indicators.powerText:Hide()
@@ -2270,9 +2266,10 @@ end
 UnitButton_UpdatePowerMax = function(self)
     if not (self._shouldShowPowerBar and self.states.powerMax) then return end
 
-    -- powerMax is non-secret for player units; may be secret for some NPCs in instances (Midnight 12.0.0+)
-    -- SetMinMaxValues/SetMinMaxSmoothedValue accept secrets; pass through directly
-    if barAnimationType == "Smooth" then
+    -- powerMax may be secret on Midnight 12.0.0+ for some units.
+    -- SetMinMaxSmoothedValue is a Lua mixin that does arithmetic (Clamp) â€" fails on secrets.
+    -- SetMinMaxValues is native C API that accepts secrets. Use it as fallback on Midnight.
+    if barAnimationType == "Smooth" and F.IsValueNonSecret(self.states.powerMax) then
         self.widgets.powerBar:SetMinMaxSmoothedValue(0, self.states.powerMax)
     else
         self.widgets.powerBar:SetMinMaxValues(0, self.states.powerMax)
@@ -2283,8 +2280,13 @@ UnitButton_UpdatePower = function(self)
     if not (self._shouldShowPowerBar and self.states.power) then return end
 
     -- self.states.power may be a secret value on Midnight 12.0.0+
-    -- SetValue/SetBarValue accepts secrets, so no change needed here
-    self.widgets.powerBar:SetBarValue(self.states.power)
+    -- SetBarValue maps to SetSmoothedValue in Smooth mode, which does Lua Clamp and fails on secrets.
+    -- Use native SetValue on Midnight when power is secret.
+    if Cell.isMidnight and not F.IsValueNonSecret(self.states.power) then
+        self.widgets.powerBar:SetValue(self.states.power)
+    else
+        self.widgets.powerBar:SetBarValue(self.states.power)
+    end
 end
 
 UnitButton_UpdatePowerType = function(self)
@@ -2315,12 +2317,10 @@ local function UnitButton_UpdateHealthMax(self)
 
     if Cell.isMidnight and self.widgets.healthCalculator then
         -- MIDNIGHT PATH: pass secret maxHealth directly
+        -- SetMinMaxSmoothedValue is a Lua mixin that does arithmetic (Clamp) â€” fails on secrets.
+        -- Always use native SetMinMaxValues on Midnight since maxHealth may be secret.
         local maxHealth = self.widgets.healthCalculator:GetMaximumHealth()
-        if barAnimationType == "Smooth" then
-            self.widgets.healthBar:SetMinMaxSmoothedValue(0, maxHealth)
-        else
-            self.widgets.healthBar:SetMinMaxValues(0, maxHealth) -- TODO: test SetMinMaxValues with secret max on PTR
-        end
+        self.widgets.healthBar:SetMinMaxValues(0, maxHealth)
         -- Also update overlay bar ranges
         if self.widgets.incomingHeal then
             self.widgets.incomingHeal:SetMinMaxValues(0, maxHealth)
@@ -2360,13 +2360,12 @@ local function UnitButton_UpdateHealth(self, diff, skipStateUpdates)
         -- MIDNIGHT PATH: pass secret values directly to status bar
         local calc = self.widgets.healthCalculator
         local health = calc:GetCurrentHealth()
-        -- SetValue accepts secrets
+        -- Always use native SetValue on Midnight — SetSmoothedValue (SetBarValue in Smooth mode)
+        -- is a Lua mixin that does Clamp() arithmetic, which fails on secret values.
+        self.widgets.healthBar:SetValue(health)
         if barAnimationType == "Flash" then
-            self.widgets.healthBar:SetValue(health)
             -- Flash: we can't compute exact diff without arithmetic on secrets, so skip precise flash
             B.HideFlash(self)
-        else
-            self.widgets.healthBar:SetBarValue(health)
         end
 
         if Cell.vars.useThresholdColor or Cell.vars.useFullColor then
@@ -2388,7 +2387,7 @@ local function UnitButton_UpdateHealth(self, diff, skipStateUpdates)
                 -- EvaluateCurrentHealthPercent feeds secret health% into the curve
                 -- Curve output: 1.0 if below threshold (needs healing), outOfRangeAlpha if above
                 local targetAlpha = self.widgets.healthCalculator:EvaluateCurrentHealthPercent(fadeOutHealthCurve)
-                -- targetAlpha is a secret value — SetAlpha accepts secrets on Midnight
+                -- targetAlpha is a secret value â€” SetAlpha accepts secrets on Midnight
                 self:SetAlpha(targetAlpha)
             end
         end
@@ -2431,24 +2430,39 @@ local function UnitButton_UpdateHealth(self, diff, skipStateUpdates)
 end
 
 local function UnitButton_UpdateHealPrediction(self, skipStateUpdates)
-    if Cell.isMidnight and self.widgets.healthCalculator then
-        -- MIDNIGHT PATH: use calculator secret values
+    if Cell.isMidnight and self.widgets.healPredictionCalculator then
+        -- MIDNIGHT PATH: use a DEDICATED calculator for heal prediction.
+        -- This keeps clamp/overflow settings isolated from the shared
+        -- healthCalculator used by health, absorb, and heal-absorb reads.
+        -- Bar is anchored to health fill edge (set in SetOrientation).
+        -- SetMinMaxValues(0, maxHealth) + SetValue(incomingHeals) lets the
+        -- C++ widget compute the proportional fill natively with secrets.
         if not predictionEnabled then
             self.widgets.incomingHeal:Hide()
             return
         end
         local unit = self.states.displayedUnit
         if not unit then return end
-        -- Refresh calculator so we have current data (critical for standalone UNIT_HEAL_PREDICTION events)
-        UnitButton_UpdateCalculator(self)
-        -- GetIncomingHeals returns: amount (all healers), amountFromHealer, amountFromOthers, clamped
-        -- We use the first return (amount) which includes heals from ALL healers in the raid
-        local incomingHeals = self.widgets.healthCalculator:GetIncomingHeals()
-        self.widgets.incomingHeal:SetValue(incomingHeals)
-        self.widgets.incomingHeal:Show()
+        local calc = self.widgets.healPredictionCalculator
+        -- Configure clamp: 0 = MissingHealth (no overheal past frame edge)
+        calc:SetIncomingHealClampMode(0)
+        calc:SetIncomingHealOverflowPercent(1.0)
+        -- Populate calculator with fresh data
+        UnitGetDetailedHealPrediction(unit, "player", calc)
+        local maxHealth = calc:GetMaximumHealth()
+        local incomingHeals = calc:GetIncomingHeals()
+        local bar = self.widgets.incomingHeal
+        -- Set explicit size: bar fills from health edge across remaining bar space
+        if self.orientation == "horizontal" then
+            bar:SetWidth(self.widgets.healthBar:GetWidth())
+        else
+            bar:SetHeight(self.widgets.healthBar:GetHeight())
+        end
+        bar:SetMinMaxValues(0, maxHealth)
+        bar:SetValue(incomingHeals)
+        bar:Show()
         return
     end
-
     -- CLASSIC/PRE-MIDNIGHT PATH: original logic
     if not predictionEnabled then
         self.widgets.incomingHeal:Hide()
@@ -2492,7 +2506,7 @@ UnitButton_UpdateShieldAbsorbs = function(self, skipStateUpdates)
         self.widgets.shieldBar:Show()
 
         -- Overshield glow and reverse-fill bar
-        -- NOTE: absorbs is a secret value on Midnight — we can't compare it to health to detect overshield.
+        -- NOTE: absorbs is a secret value on Midnight â€” we can't compare it to health to detect overshield.
         -- Show the glow whenever shields are present and overshieldEnabled is on.
         -- TODO: Use a Curve to map (absorbs + health - maxHealth) to glow visibility for precise overshield detection.
         if overshieldReverseFillEnabled then
@@ -2740,7 +2754,7 @@ UnitButton_UpdateStatusText = function(self)
         statusText:Show()
         statusText:SetStatus("OFFLINE")
         statusText:ShowTimer()
-    -- Midnight 12.0.0+: UnitIsAFK may return a secret boolean — skip on Midnight
+    -- Midnight 12.0.0+: UnitIsAFK may return a secret boolean â€” skip on Midnight
     elseif not Cell.isMidnight and UnitIsAFK(unit) then
         statusText:Show()
         statusText:SetStatus("AFK")
@@ -3032,7 +3046,7 @@ local function UnitButton_RegisterEvents(self)
     -- self:RegisterEvent("UNIT_PET")
     self:RegisterEvent("UNIT_PORTRAIT_UPDATE") -- pet summoned far away
 
-    --! OnShow时立即执行，但UpdateIndicators可能并未执行完毕，导致在ResetCustomIndicators过程中指示器发生变化，进而报错
+    --! OnShowæ—¶ç«‹å³æ‰§è¡Œï¼Œä½†UpdateIndicatorså¯èƒ½å¹¶æœªæ‰§è¡Œå®Œæ¯•ï¼Œå¯¼è‡´åœ¨ResetCustomIndicatorsè¿‡ç¨‹ä¸­æŒ‡ç¤ºå™¨å‘ç”Ÿå˜åŒ–ï¼Œè¿›è€ŒæŠ¥é”™
     local success, result = pcall(UnitButton_UpdateAll, self)
     if not success then
         F.Debug("UnitButton_UpdateAll |cffff0000FAILED:|r", self:GetName(), result)
@@ -3339,7 +3353,7 @@ local function UnitButton_OnTick(self)
                 -- update Cell.vars.guids
                 self.__unitGuid = guid
                 -- On Midnight 12.0.0+, GUIDs for non-player units in instances are secret
-                -- Can't use a secret as a table key — only store non-secret GUIDs
+                -- Can't use a secret as a table key â€” only store non-secret GUIDs
                 if not self.isSpotlight then
                     if not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid)) then
                         Cell.vars.guids[guid] = self.states.unit
@@ -3356,7 +3370,7 @@ local function UnitButton_OnTick(self)
                         self.__nameRetries = nil
                     else
                         -- NOTE: update on next tick
-                        -- 国服可以起名为“未知目标”，干！就只多重试4次好了
+                        -- å›½æœå¯ä»¥èµ·åä¸ºâ€œæœªçŸ¥ç›®æ ‡â€ï¼Œå¹²ï¼å°±åªå¤šé‡è¯•4æ¬¡å¥½äº†
                         self.__nameRetries = (self.__nameRetries or 0) + 1
                         self.__unitGuid = nil
                     end
@@ -3716,7 +3730,10 @@ function B.SetOrientation(button, orientation, rotateTexture)
         P.Height(gapTexture, CELL_BORDER_SIZE)
 
         if Cell.isMidnight then
-            -- Midnight: StatusBars use SetAllPoints(healthBar) + native fill; just set orientation
+            -- Midnight: anchor incomingHeal to health fill edge so it starts where health ends
+            P.ClearPoints(incomingHeal)
+            P.Point(incomingHeal, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+            P.Point(incomingHeal, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "BOTTOMRIGHT")
             incomingHeal:SetOrientation("horizontal")
             shieldBar:SetOrientation("horizontal")
             shieldBarR:SetOrientation("horizontal")
@@ -3804,7 +3821,10 @@ function B.SetOrientation(button, orientation, rotateTexture)
         end
 
         if Cell.isMidnight then
-            -- Midnight: StatusBars use SetAllPoints(healthBar) + native fill; just set orientation
+            -- Midnight: anchor incomingHeal to health fill edge so it starts where health ends
+            P.ClearPoints(incomingHeal)
+            P.Point(incomingHeal, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "TOPLEFT")
+            P.Point(incomingHeal, "BOTTOMRIGHT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
             incomingHeal:SetOrientation("vertical")
             shieldBar:SetOrientation("vertical")
             shieldBarR:SetOrientation("vertical")
@@ -4093,6 +4113,9 @@ function CellUnitButton_OnLoad(button)
     -- Health prediction calculator (Patch 12.0.0+)
     if Cell.isMidnight and CreateUnitHealPredictionCalculator then
         button.widgets.healthCalculator = CreateUnitHealPredictionCalculator()
+        -- Separate calculator for heal prediction so clamp settings don't
+        -- corrupt the shared healthCalculator used by health/absorb reads.
+        button.widgets.healPredictionCalculator = CreateUnitHealPredictionCalculator()
     end
     -- Color curve for health bar coloring (Patch 12.0.0+)
     if Cell.isMidnight and C_CurveUtil then
@@ -4176,17 +4199,18 @@ function CellUnitButton_OnLoad(button)
     local incomingHeal
     if Cell.isMidnight then
         -- Midnight: StatusBar so native SetMinMaxValues/SetValue work with secret values
+        -- Health values are always secret in instances, so we must use calculator-based StatusBar
         incomingHeal = CreateFrame("StatusBar", name.."IncomingHealBar", healthBar)
         incomingHeal:SetStatusBarTexture(Cell.vars.texture)
         incomingHeal:GetStatusBarTexture():SetDrawLayer("ARTWORK", -6)
         incomingHeal:SetFrameLevel(healthBar:GetFrameLevel()+1)
-        incomingHeal:SetAllPoints(healthBar)
+        -- Positioned by SetOrientation (anchored to health fill edge, not SetAllPoints)
         -- Compatibility shims: map Texture methods to StatusBar equivalents
         incomingHeal.SetVertexColor = incomingHeal.SetStatusBarColor
         incomingHeal.SetTexture = incomingHeal.SetStatusBarTexture
     else
         -- Pre-Midnight: Texture with manual width/height positioning
-        incomingHeal = healthBar:CreateTexture(name.."IncomingHealBar", "ARTWORK", nil, -6)
+        incomingHeal = healthBar:CreateTexture(name.."IncomingHealBar", "ARTWORK", nil, -3)
         incomingHeal:SetTexture(Cell.vars.texture)
         incomingHeal.SetValue = DumbFunc
     end

--- a/RaidFrames/UnitButton.xml
+++ b/RaidFrames/UnitButton.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Button name="CellUnitButtonTemplate" inherits="BackdropTemplate,SecureUnitButtonTemplate,SecureHandlerEnterLeaveTemplate,SecureHandlerShowHideTemplate" hidden="true" virtual="true">
         <Attributes>
             <Attribute name="toggleForVehicle" type="boolean" value="true"/>

--- a/Revise.lua
+++ b/Revise.lua
@@ -3413,6 +3413,16 @@ function F.Revise()
         end
     end
 
+    -- Migration for Cell r275 (Midnight 12.0.0 compatibility)
+    if not CellDB["revise"] or dbRevision < 275 then
+        -- Remove useCleuHealthUpdater setting (CLEU-based health updater removed in 12.0.0)
+        if CellDB["general"] then
+            CellDB["general"]["useCleuHealthUpdater"] = nil
+        end
+        -- Note: profile import compatibility warning added elsewhere.
+        -- Saved variable secrets: any secrets stored before this version will be nil'd by WoW.
+    end
+
     -- ----------------------------------------------------------------------- --
     --            update from old versions, validate all indicators            --
     -- ----------------------------------------------------------------------- --

--- a/Utilities/BuffTracker.lua
+++ b/Utilities/BuffTracker.lua
@@ -693,18 +693,19 @@ end, unpack(fadeOuts))
 local GetAuraDataBySpellName = C_UnitAuras.GetAuraDataBySpellName
 
 local function UnitBuffExists(unit, buff)
-    -- C_UnitAuras.GetAuraDataBySpellName is blocked when auras are restricted (Midnight 12.0.0+)
-    -- Guard: bail out early so we don't error; treat all buffs as absent during restrictions
-    if Cell.isMidnight and F.IsAuraRestricted() then return end
-
     local names = buffs[buff]["names"]
     local aura
     for _, name in next, names do
         aura = GetAuraDataBySpellName(unit, name, "HELPFUL")
         if aura then
-            -- aura.sourceUnit is a secret field on Midnight during restrictions,
-            -- but we only reach here when not restricted, so this is safe
-            return true, aura.sourceUnit == "player"
+            -- Midnight 12.0.0+: raid buff spell IDs (1459, 6673, 21562, 462854, etc.) are flagged
+            -- non-secret by Blizzard, so their aura fields (including sourceUnit) are real values.
+            -- For any unexpected secret aura, treat as present but not provided by player.
+            if F.IsAuraNonSecret(aura) then
+                return true, aura.sourceUnit == "player"
+            else
+                return true
+            end
         end
     end
 end

--- a/Utilities/BuffTracker.lua
+++ b/Utilities/BuffTracker.lua
@@ -693,11 +693,17 @@ end, unpack(fadeOuts))
 local GetAuraDataBySpellName = C_UnitAuras.GetAuraDataBySpellName
 
 local function UnitBuffExists(unit, buff)
+    -- C_UnitAuras.GetAuraDataBySpellName is blocked when auras are restricted (Midnight 12.0.0+)
+    -- Guard: bail out early so we don't error; treat all buffs as absent during restrictions
+    if Cell.isMidnight and F.IsAuraRestricted() then return end
+
     local names = buffs[buff]["names"]
     local aura
     for _, name in next, names do
         aura = GetAuraDataBySpellName(unit, name, "HELPFUL")
         if aura then
+            -- aura.sourceUnit is a secret field on Midnight during restrictions,
+            -- but we only reach here when not restricted, so this is safe
             return true, aura.sourceUnit == "player"
         end
     end

--- a/Utilities/DeathReport.lua
+++ b/Utilities/DeathReport.lua
@@ -3,6 +3,8 @@ local L = Cell.L
 local F = Cell.funcs
 
 local UnitIsFeignDeath = UnitIsFeignDeath
+local UnitIsDeadOrGhost = UnitIsDeadOrGhost
+local UnitName = UnitName
 local IsInGroup = IsInGroup
 local IsEncounterInProgress = IsEncounterInProgress
 local GetSpellLink = C_Spell.GetSpellLink or GetSpellLink
@@ -11,46 +13,12 @@ local GetSpellLink = C_Spell.GetSpellLink or GetSpellLink
 -- vars
 ----------------------------------------------------
 local init, instanceType, inInstance
-local deathLogs = {
-    -- time, type, name, ability, school, amount, overkill, resisted, blocked, absorbed, critical, sourceName
-}
 local limit, count
-local blacklist = {
-    [124255] = true
-}
-
-local overkillFormat, resistedFormat, blockedFormat, absorbedFormat, criticalText
-if Cell.isAsian then
-    overkillFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_OVERKILLING, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_OVERKILLING)-3)
-    resistedFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_RESIST, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_RESIST)-3)
-    blockedFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_BLOCK, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_BLOCK)-3)
-    absorbedFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_ABSORB, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_ABSORB)-3)
-    criticalText = string.sub(_G.TEXT_MODE_A_STRING_RESULT_CRITICAL, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_CRITICAL)-3)
-else
-    overkillFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_OVERKILLING, "[()]", ""))
-    resistedFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_RESIST, "[()]", ""))
-    blockedFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_BLOCK, "[()]", ""))
-    absorbedFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_ABSORB, "[()]", ""))
-    criticalText = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_CRITICAL, "[()]", ""))
-end
 
 ----------------------------------------------------
--- functions
+-- Send helper (shared by both paths)
 ----------------------------------------------------
-local function UpdateDeathLog(guid, ...)
-    if not deathLogs[guid] then
-        deathLogs[guid] = {}
-    end
-
-    deathLogs[guid]["time"], deathLogs[guid]["type"], deathLogs[guid]["name"], deathLogs[guid]["ability"],
-    deathLogs[guid]["school"], deathLogs[guid]["amount"], deathLogs[guid]["overkill"], deathLogs[guid]["resisted"],
-    deathLogs[guid]["blocked"], deathLogs[guid]["absorbed"], deathLogs[guid]["critical"], deathLogs[guid]["sourceName"] = ...
-
-    deathLogs[guid]["reported"] = false
-end
-
 local function Send(msg)
-    -- F.Print(strupper(ACTION_UNIT_DIED)..": "..msg)
     if Cell.hasHighestPriority then
         if IsInGroup(LE_PARTY_CATEGORY_INSTANCE) then
             SendChatMessage(strupper(ACTION_UNIT_DIED)..": "..msg, "INSTANCE_CHAT")
@@ -60,74 +28,185 @@ local function Send(msg)
     end
 end
 
-local function Report(guid)
-    if not deathLogs[guid] or deathLogs[guid]["reported"] then return end
-    deathLogs[guid]["reported"] = true
-
+local function CheckSendLimit()
     if instanceType == "raid" and IsEncounterInProgress() then
         count = count + 1
         if count > limit then
-            return
+            return false
         end
     end
-
-    if not deathLogs[guid]["type"] or time()-deathLogs[guid]["time"]>=1 then -- unkown
-        -- Send(deathLogs[guid]["name"].." > "..strlower(_G.UNKNOWN))
-        Send(deathLogs[guid]["name"])
-
-    elseif deathLogs[guid]["type"] == "INSTAKILL" then
-        Send(deathLogs[guid]["name"].." > "..L["instakill"])
-
-    elseif deathLogs[guid]["type"] == "ENVIRONMENTAL" then
-        Send(deathLogs[guid]["name"].." > "..F.FormatNumber(deathLogs[guid]["amount"]).." ("..deathLogs[guid]["ability"]..")")
-
-    else -- SPELL & RANGE & SWING
-        -- local damageDetails = {}
-        local damageDetails = ""
-
-        if deathLogs[guid]["overkill"] > 0 then
-            -- tinsert(damageDetails, string.format(overkillFormat, F.FormatNumber(deathLogs[guid]["overkill"])))
-            damageDetails = " ("..string.format(overkillFormat, F.FormatNumber(deathLogs[guid]["overkill"]))..") "
-        end
-        -- if deathLogs[guid]["critical"] == 1 then
-        --     tinsert(damageDetails, criticalText)
-        -- end
-        -- if deathLogs[guid]["resisted"] then
-        --     tinsert(damageDetails, string.format(resistedFormat, F.FormatNumber(deathLogs[guid]["resisted"])))
-        -- end
-        -- if deathLogs[guid]["blocked"] then
-        --     tinsert(damageDetails, string.format(blockedFormat, F.FormatNumber(deathLogs[guid]["blocked"])))
-        -- end
-        -- if deathLogs[guid]["absorbed"] then
-        --     tinsert(damageDetails, string.format(absorbedFormat, F.FormatNumber(deathLogs[guid]["absorbed"])))
-        -- end
-
-        -- damageDetails = table.concat(damageDetails, ", ")
-
-        local sourceName = (deathLogs[guid]["sourceName"] and deathLogs[guid]["name"]~=deathLogs[guid]["sourceName"]) and (" ["..deathLogs[guid]["sourceName"].."]") or ""
-        local ability
-
-        if deathLogs[guid]["type"] == "SPELL" then -- including RANGE
-            -- tinsert(damageDetails, strlower(CombatLog_String_SchoolString(deathLogs[guid]["school"])))
-            ability = deathLogs[guid]["ability"]
-        else -- SWING
-            ability = strlower(_G.MELEE)
-        end
-
-        -- damageDetails = table.concat(damageDetails, ", ")
-        -- if damageDetails ~= "" then damageDetails = " ("..damageDetails..") " end
-        Send(deathLogs[guid]["name"].." > "..ability.." "..F.FormatNumber(deathLogs[guid]["amount"])..damageDetails..sourceName)
-    end
-
-    -- wipe(deathLogs[guid])
+    return true
 end
 
 ----------------------------------------------------
--- event
+-- CLEU-detailed path (pre-Midnight retail + Classic)
+-- COMBAT_LOG_EVENT_UNFILTERED is removed in 12.0.0 (Midnight).
+-- This entire block is skipped when Cell.isMidnight is true.
 ----------------------------------------------------
+local deathLogs -- declared here; only allocated for the CLEU path
 local frame = CreateFrame("Frame")
--- frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
 
+if not Cell.isMidnight then
+    local blacklist = {
+        [124255] = true
+    }
+
+    local overkillFormat, resistedFormat, blockedFormat, absorbedFormat, criticalText
+    if Cell.isAsian then
+        overkillFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_OVERKILLING, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_OVERKILLING)-3)
+        resistedFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_RESIST, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_RESIST)-3)
+        blockedFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_BLOCK, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_BLOCK)-3)
+        absorbedFormat = string.sub(_G.TEXT_MODE_A_STRING_RESULT_ABSORB, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_ABSORB)-3)
+        criticalText = string.sub(_G.TEXT_MODE_A_STRING_RESULT_CRITICAL, 4, string.len(_G.TEXT_MODE_A_STRING_RESULT_CRITICAL)-3)
+    else
+        overkillFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_OVERKILLING, "[()]", ""))
+        resistedFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_RESIST, "[()]", ""))
+        blockedFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_BLOCK, "[()]", ""))
+        absorbedFormat = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_ABSORB, "[()]", ""))
+        criticalText = strlower(string.gsub(_G.TEXT_MODE_A_STRING_RESULT_CRITICAL, "[()]", ""))
+    end
+
+    deathLogs = {
+        -- time, type, name, ability, school, amount, overkill, resisted, blocked, absorbed, critical, sourceName
+    }
+
+    local function UpdateDeathLog(guid, ...)
+        if not deathLogs[guid] then
+            deathLogs[guid] = {}
+        end
+
+        deathLogs[guid]["time"], deathLogs[guid]["type"], deathLogs[guid]["name"], deathLogs[guid]["ability"],
+        deathLogs[guid]["school"], deathLogs[guid]["amount"], deathLogs[guid]["overkill"], deathLogs[guid]["resisted"],
+        deathLogs[guid]["blocked"], deathLogs[guid]["absorbed"], deathLogs[guid]["critical"], deathLogs[guid]["sourceName"] = ...
+
+        deathLogs[guid]["reported"] = false
+    end
+
+    local function Report(guid)
+        if not deathLogs[guid] or deathLogs[guid]["reported"] then return end
+        deathLogs[guid]["reported"] = true
+
+        if not CheckSendLimit() then return end
+
+        if not deathLogs[guid]["type"] or time()-deathLogs[guid]["time"]>=1 then -- unknown
+            Send(deathLogs[guid]["name"])
+
+        elseif deathLogs[guid]["type"] == "INSTAKILL" then
+            Send(deathLogs[guid]["name"].." > "..L["instakill"])
+
+        elseif deathLogs[guid]["type"] == "ENVIRONMENTAL" then
+            Send(deathLogs[guid]["name"].." > "..F.FormatNumber(deathLogs[guid]["amount"]).." ("..deathLogs[guid]["ability"]..")")
+
+        else -- SPELL & RANGE & SWING
+            local damageDetails = ""
+
+            if deathLogs[guid]["overkill"] > 0 then
+                damageDetails = " ("..string.format(overkillFormat, F.FormatNumber(deathLogs[guid]["overkill"]))..") "
+            end
+
+            local sourceName = (deathLogs[guid]["sourceName"] and deathLogs[guid]["name"]~=deathLogs[guid]["sourceName"]) and (" ["..deathLogs[guid]["sourceName"].."]") or ""
+            local ability
+
+            if deathLogs[guid]["type"] == "SPELL" then -- including RANGE
+                ability = deathLogs[guid]["ability"]
+            else -- SWING
+                ability = strlower(_G.MELEE)
+            end
+
+            Send(deathLogs[guid]["name"].." > "..ability.." "..F.FormatNumber(deathLogs[guid]["amount"])..damageDetails..sourceName)
+        end
+    end
+
+    function frame:COMBAT_LOG_EVENT_UNFILTERED(...)
+        local timestamp, event, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, arg12, arg13, arg14 = ...
+        local amount, overkill, school, resisted, blocked, absorbed, critical
+
+        if string.find(destGUID, "^Player") and F.IsFriend(destFlags) then
+            if event == "SPELL_INSTAKILL" then
+                UpdateDeathLog(destGUID, timestamp, "INSTAKILL", destName)
+            end
+
+            if event == "ENVIRONMENTAL_DAMAGE" then
+                amount, overkill, school, resisted, blocked, absorbed, critical = select(13, ...)
+                amount = amount == 0 and absorbed or amount
+                UpdateDeathLog(destGUID, timestamp, "ENVIRONMENTAL", destName, strlower(_G["ACTION_ENVIRONMENTAL_DAMAGE_" .. strupper(arg12)]), nil, amount)
+            end
+
+            if event == "SWING_DAMAGE" then
+                amount, overkill, school, resisted, blocked, absorbed, critical = select(12, ...)
+                UpdateDeathLog(destGUID, timestamp, "SWING", destName, nil, school, amount, overkill or -1, resisted, blocked, absorbed, critical, sourceName)
+            end
+
+            if event == "SPELL_DAMAGE" or event == "SPELL_PERIODIC_DAMAGE" or event == "RANGE_DAMAGE" then
+                if not blacklist[arg12] then
+                    amount, overkill, school, resisted, blocked, absorbed, critical = select(15, ...)
+                    local spellLink = GetSpellLink(arg12)
+                    UpdateDeathLog(destGUID, timestamp, "SPELL", destName, spellLink, school, amount, overkill or -1, resisted, blocked, absorbed, critical, sourceName)
+                end
+            end
+
+            if event == "SPELL_AURA_APPLIED" then
+                if arg12 == 27827 or arg12 == 358164 then -- 救赎之魂 or 灵魂疲惫
+                    C_Timer.After(0.25, function()
+                        Report(destGUID)
+                    end)
+                end
+            end
+
+            if event == "UNIT_DIED" and not UnitIsFeignDeath(destName) then
+                C_Timer.After(0.5, function()
+                    if not deathLogs[destGUID] then deathLogs[destGUID] = {["name"]=destName} end
+                    Report(destGUID)
+                end)
+            end
+        end
+    end
+
+    frame:SetScript("OnEvent", function(self, event, ...)
+        if event == "COMBAT_LOG_EVENT_UNFILTERED" then
+            self:COMBAT_LOG_EVENT_UNFILTERED(CombatLogGetCurrentEventInfo())
+        else
+            self[event](self, ...)
+        end
+    end)
+else
+    -- Midnight (12.0.0+): COMBAT_LOG_EVENT_UNFILTERED is unavailable.
+    -- Simplified death detection: track group units via UNIT_HEALTH and
+    -- report death when UnitIsDeadOrGhost() becomes true.
+    -- The detailed "killed by X for Y" info is not available without CLEU.
+    local reportedDead = {} -- guid -> true when already reported this death
+
+    local function OnUnitHealth(unit)
+        if not unit then return end
+        if UnitIsDeadOrGhost(unit) and not UnitIsFeignDeath(unit) then
+            local guid = UnitGUID(unit)
+            if guid and not reportedDead[guid] then
+                reportedDead[guid] = true
+                if not CheckSendLimit() then return end
+                local name = UnitName(unit) or unit
+                Send(name)
+            end
+        else
+            -- unit is alive again; allow future death reports
+            local guid = UnitGUID(unit)
+            if guid then
+                reportedDead[guid] = nil
+            end
+        end
+    end
+
+    frame:SetScript("OnEvent", function(self, event, ...)
+        if event == "UNIT_HEALTH" then
+            OnUnitHealth(...)
+        elseif self[event] then
+            self[event](self, ...)
+        end
+    end)
+end
+
+----------------------------------------------------
+-- Shared event handlers (both paths)
+----------------------------------------------------
 function frame:PLAYER_ENTERING_WORLD()
     local isIn, iType = IsInInstance()
     instanceType = iType
@@ -135,7 +214,9 @@ function frame:PLAYER_ENTERING_WORLD()
     if instanceType == "pvp" or instanceType == "arena" then
         frame:UnregisterEvent("ENCOUNTER_START")
         frame:UnregisterEvent("ENCOUNTER_END")
-        frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        if not Cell.isMidnight then
+            frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        end
         frame:UnregisterEvent("GROUP_ROSTER_UPDATE")
         return
     else
@@ -151,12 +232,11 @@ function frame:PLAYER_ENTERING_WORLD()
         else
             frame:UnregisterEvent("ENCOUNTER_START")
         end
-    elseif inInstance then -- left insntance
+    elseif inInstance then -- left instance
         inInstance = false
-        wipe(deathLogs)
+        if deathLogs then wipe(deathLogs) end
         frame:UnregisterEvent("ENCOUNTER_START")
     end
-    -- texplore(deathLogs)
 end
 
 local timer
@@ -171,7 +251,9 @@ function frame:GROUP_ROSTER_UPDATE()
             end)
         end
     else
-        frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        if not Cell.isMidnight then
+            frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        end
     end
     init = true
 end
@@ -185,71 +267,14 @@ function frame:ENCOUNTER_START()
     count = 0
 end
 
-function frame:COMBAT_LOG_EVENT_UNFILTERED(...)
-    local timestamp, event, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, arg12, arg13, arg14 = ...
-    local amount, overkill, school, resisted, blocked, absorbed, critical -- glancing, crushing
-
-    -- arg12, arg13, arg14,
-    -- UNIT_DIED: recapID, unconsciousOnDeath
-    -- ENVIRONMENTAL: environmentalType
-    -- SPELL/RANGE: spellId, spellName, spellSchool
-
-    -- if string.find(destGUID, "^Player") then -- debug
-    if string.find(destGUID, "^Player") and F.IsFriend(destFlags) then
-        if event == "SPELL_INSTAKILL" then
-            UpdateDeathLog(destGUID, timestamp, "INSTAKILL", destName)
-        end
-
-        if event == "ENVIRONMENTAL_DAMAGE" then
-            amount, overkill, school, resisted, blocked, absorbed, critical = select(13, ...)
-            amount = amount == 0 and absorbed or amount
-            -- _G.ENVIRONMENTAL_DAMAGE.." "..
-            UpdateDeathLog(destGUID, timestamp, "ENVIRONMENTAL", destName, strlower(_G["ACTION_ENVIRONMENTAL_DAMAGE_" .. strupper(arg12)]), nil, amount)
-        end
-
-        if event == "SWING_DAMAGE" then
-            amount, overkill, school, resisted, blocked, absorbed, critical = select(12, ...)
-            UpdateDeathLog(destGUID, timestamp, "SWING", destName, nil, school, amount, overkill or -1, resisted, blocked, absorbed, critical, sourceName)
-        end
-
-        if event == "SPELL_DAMAGE" or event == "SPELL_PERIODIC_DAMAGE" or event == "RANGE_DAMAGE" then
-            if not blacklist[arg12] then
-                amount, overkill, school, resisted, blocked, absorbed, critical = select(15, ...)
-                local spellLink = GetSpellLink(arg12)
-                UpdateDeathLog(destGUID, timestamp, "SPELL", destName, spellLink, school, amount, overkill or -1, resisted, blocked, absorbed, critical, sourceName)
-            end
-        end
-
-        if event == "SPELL_AURA_APPLIED" then
-            -- print(arg12, arg13, arg14)
-            if arg12 == 27827 or arg12 == 358164 then -- 救赎之魂 or 灵魂疲惫
-                C_Timer.After(0.25, function()
-                    Report(destGUID)
-                end)
-            end
-        end
-
-        if event == "UNIT_DIED" and not UnitIsFeignDeath(destName) then
-            C_Timer.After(0.5, function()
-                if not deathLogs[destGUID] then deathLogs[destGUID] = {["name"]=destName} end
-                Report(destGUID)
-            end)
-        end
-    end
-end
-
-frame:SetScript("OnEvent", function(self, event, ...)
-    if event == "COMBAT_LOG_EVENT_UNFILTERED" then
-        self:COMBAT_LOG_EVENT_UNFILTERED(CombatLogGetCurrentEventInfo())
-    else
-        self[event](self, ...)
-    end
-end)
-
 ----------------------------------------------------
 -- priority
 ----------------------------------------------------
 local function UpdatePriority(hasHighestPriority)
+    if Cell.isMidnight then
+        -- Midnight: CLEU unavailable; UNIT_HEALTH registration is handled in UpdateTools
+        return
+    end
     if hasHighestPriority and CellDB["tools"]["deathReport"][1] then
         frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     else
@@ -267,6 +292,11 @@ local function UpdateTools(which)
         if CellDB["tools"]["deathReport"][1] then
             frame:RegisterEvent("PLAYER_ENTERING_WORLD")
             frame:RegisterEvent("GROUP_ROSTER_UPDATE")
+            if Cell.isMidnight then
+                -- Midnight: use UNIT_HEALTH on all roster units to detect deaths.
+                -- UnitHealth() is secret but UnitIsDeadOrGhost() is not.
+                frame:RegisterEvent("UNIT_HEALTH")
+            end
 
             limit = CellDB["tools"]["deathReport"][2]
             count = 0
@@ -276,7 +306,7 @@ local function UpdateTools(which)
             enabled = true
         else
             frame:UnregisterAllEvents()
-            wipe(deathLogs)
+            if deathLogs then wipe(deathLogs) end
             enabled = false
         end
     end

--- a/Utilities/LoadUtilities.xml
+++ b/Utilities/LoadUtilities.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="BattleRes.lua"/>
     <Script file="Marks.lua"/>
     <Script file="ReadyAndPull.lua"/>

--- a/Utilities/LoadUtilities_Classic.xml
+++ b/Utilities/LoadUtilities_Classic.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Marks.lua"/>
     <Script file="ReadyAndPull.lua"/>
     <Script file="RaidRosterFrame.lua"/>

--- a/Utilities/LoadUtilities_Mists.xml
+++ b/Utilities/LoadUtilities_Mists.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Marks.lua"/>
     <Script file="ReadyAndPull.lua"/>
     <Script file="RaidRosterFrame.lua"/>

--- a/Utilities/QuickAssist.lua
+++ b/Utilities/QuickAssist.lua
@@ -297,6 +297,8 @@ end
 
 local function QuickAssist_UpdateCasts(self, spellId)
     if not self.unit then return end
+    -- Midnight 12.0.0+: spellId from UNIT_SPELLCAST_SUCCEEDED is secret during restricted contexts
+    if Cell.isMidnight and issecretvalue and issecretvalue(spellId) then return end
     if not offensiveCasts[spellId] then return end
 
     self._casts[spellId] = GetTime()

--- a/Utilities/QuickAssist.xml
+++ b/Utilities/QuickAssist.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Button name="CellQuickAssistButtonTemplate" inherits="BackdropTemplate,SecureUnitButtonTemplate,SecureHandlerEnterLeaveTemplate,SecureHandlerShowHideTemplate" hidden="true" virtual="true">
         <Attributes>
             <Attribute name="checkselfcast" type="boolean" value="false"/>

--- a/Utilities/QuickCast.lua
+++ b/Utilities/QuickCast.lua
@@ -893,12 +893,13 @@ end
 -- ----------------------------------------------------------------------- --
 local function QuickCast_UpdateAuras(self)
     if not self.unit then return end
-    -- Midnight 12.0.0+: AuraUtil.ForEachAura callback receives secret fields during restricted contexts
-    if Cell.isMidnight and F.IsAuraRestricted() then return end
 
     local glowBuffFound, outerBuffFound, innerBuffFound
 
     AuraUtil.ForEachAura(self.unit, "HELPFUL", nil, function(name, icon, count, debuffType, duration, expirationTime, source, isStealable, nameplateShowPersonal, spellId)
+        -- Midnight 12.0.0+: skip auras whose fields are secret; non-secret auras (e.g. raid buffs) are safe to read
+        if Cell.isMidnight and issecretvalue and issecretvalue(spellId) then return end
+
         if glowBuffs[name] then
             glowBuffFound = true
             self:SetGlowBuffCooldown(expirationTime - duration, duration)

--- a/Utilities/QuickCast.lua
+++ b/Utilities/QuickCast.lua
@@ -893,6 +893,8 @@ end
 -- ----------------------------------------------------------------------- --
 local function QuickCast_UpdateAuras(self)
     if not self.unit then return end
+    -- Midnight 12.0.0+: AuraUtil.ForEachAura callback receives secret fields during restricted contexts
+    if Cell.isMidnight and F.IsAuraRestricted() then return end
 
     local glowBuffFound, outerBuffFound, innerBuffFound
 
@@ -921,6 +923,8 @@ local function QuickCast_UpdateAuras(self)
 end
 
 local function QuickCast_UpdateCasts(self, spellId)
+    -- Midnight 12.0.0+: spellId from UNIT_SPELLCAST_SUCCEEDED is secret during restricted contexts
+    if Cell.isMidnight and issecretvalue and issecretvalue(spellId) then return end
     if glowCasts[spellId] then
         self:SetGlowCastCooldown(GetTime(), glowCasts[spellId])
     end

--- a/Utils.lua
+++ b/Utils.lua
@@ -2013,6 +2013,8 @@ end
 
 if Cell.isRetail then
     function F.FindDebuffByIds(unit, spellIds)
+        -- Midnight 12.0.0+: aura fields are secret during restricted contexts
+        if Cell.isMidnight and F.IsAuraRestricted() then return {} end
         local debuffs = {}
         AuraUtil.ForEachAura(unit, "HARMFUL", nil, function(name, icon, count, debuffType, duration, expirationTime, source, isStealable, nameplateShowPersonal, spellId)
             if spellIds[spellId] then
@@ -2023,6 +2025,8 @@ if Cell.isRetail then
     end
 
     function F.FindAuraByDebuffTypes(unit, types)
+        -- Midnight 12.0.0+: aura fields are secret during restricted contexts
+        if Cell.isMidnight and F.IsAuraRestricted() then return {} end
         local debuffs = {}
         AuraUtil.ForEachAura(unit, "HARMFUL", nil, function(name, icon, count, debuffType, duration, expirationTime, source, isStealable, nameplateShowPersonal, spellId)
             if types == "all" or types[debuffType] then
@@ -2356,6 +2360,10 @@ function F.IsInRange(unit, check)
         -- NOTE: UnitInRange only works with group players/pets
         --! but not available for PLAYER PET when SOLO
         local inRange, checked = UnitInRange(unit)
+        -- Midnight 12.0.0+: UnitInRange returns secret booleans during restricted contexts
+        if Cell.isMidnight and issecretvalue and issecretvalue(checked) then
+            return F.IsInRange(unit, true)
+        end
         if not checked then
             return F.IsInRange(unit, true)
         end
@@ -2376,7 +2384,10 @@ function F.IsInRange(unit, check)
             end
 
             local inRange, checked = UnitInRange(unit)
-            if checked then
+            -- Midnight 12.0.0+: UnitInRange returns secret booleans during restricted contexts
+            if Cell.isMidnight and issecretvalue and issecretvalue(checked) then
+                -- Skip, fall through to pet/interact checks below
+            elseif checked then
                 return inRange
             end
 

--- a/Utils.lua
+++ b/Utils.lua
@@ -2535,3 +2535,32 @@ function F.IsCooldownRestricted()
     end
     return false
 end
+
+-- Per-aura non-secret check: returns true if the aura's fields are real (non-secret) values.
+-- On Midnight 12.0.0+, Blizzard flags certain spells as non-secret; their auraInfo fields
+-- (spellId, expirationTime, duration, etc.) return real values instead of secrets.
+-- If spellId is readable (non-secret), ALL fields for this aura are non-secret.
+function F.IsAuraNonSecret(auraInfo)
+    if not Cell.isMidnight then return true end
+    if not issecretvalue then return true end
+    return not issecretvalue(auraInfo.spellId)
+end
+
+-- Proactive check: queries whether a spell ID will produce secret aura values.
+-- Uses C_Secrets.ShouldSpellAuraBeSecret() if available (Midnight 12.0.0+).
+-- Returns true if the spell's aura data will be non-secret (readable).
+function F.IsSpellAuraNonSecret(spellId)
+    if not Cell.isMidnight then return true end
+    if C_Secrets and C_Secrets.ShouldSpellAuraBeSecret then
+        return not C_Secrets.ShouldSpellAuraBeSecret(spellId)
+    end
+    return false -- assume secret if API unavailable
+end
+
+-- Generic check: returns true if a given value is NOT a secret value.
+-- Works for any return value from WoW APIs that may produce secrets on Midnight 12.0.0+.
+function F.IsValueNonSecret(val)
+    if not Cell.isMidnight then return true end
+    if not issecretvalue then return true end
+    return not issecretvalue(val)
+end

--- a/Utils.lua
+++ b/Utils.lua
@@ -14,6 +14,7 @@ Cell.vars.playerFaction = UnitFactionGroup("player")
 Cell.isAsian = LOCALE_zhCN or LOCALE_zhTW or LOCALE_koKR
 
 Cell.isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+Cell.isMidnight = Cell.isRetail and (select(4, GetBuildInfo()) >= 120000)
 Cell.isVanilla = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 Cell.isTBC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC
 Cell.isWrath = WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC
@@ -2492,4 +2493,34 @@ end
 ---------------------------------------------------------------------
 if Cell.isMists then
 
+end
+
+-------------------------------------------------
+-- Secret value utilities (Patch 12.0.0+)
+-------------------------------------------------
+-- issecretvalue() is a native WoW API available in 12.0.0+
+function F.IsSecretValue(val)
+    if issecretvalue then
+        return issecretvalue(val)
+    end
+    return false
+end
+
+-- GetRestrictedActionStatus() returns non-secret boolean
+-- Enum.RestrictedActionType.SecretAuras = 0
+-- Enum.RestrictedActionType.SecretCooldowns = 1
+function F.IsAuraRestricted()
+    if GetRestrictedActionStatus and Enum and Enum.RestrictedActionType then
+        local isRestricted = GetRestrictedActionStatus(Enum.RestrictedActionType.SecretAuras)
+        return isRestricted == true
+    end
+    return false
+end
+
+function F.IsCooldownRestricted()
+    if GetRestrictedActionStatus and Enum and Enum.RestrictedActionType then
+        local isRestricted = GetRestrictedActionStatus(Enum.RestrictedActionType.SecretCooldowns)
+        return isRestricted == true
+    end
+    return false
 end

--- a/Widgets/LoadWidgets.xml
+++ b/Widgets/LoadWidgets.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Animation.lua"/>
     <Script file="Widgets.lua"/>
     <Script file="Widgets_IndicatorSettings.lua"/>

--- a/Widgets/LoadWidgets_Classic.xml
+++ b/Widgets/LoadWidgets_Classic.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <Script file="Animation.lua"/>
     <Script file="Widgets.lua"/>
     <Script file="Widgets_IndicatorSettings.lua"/>

--- a/Widgets/TooltipTemplate.xml
+++ b/Widgets/TooltipTemplate.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <GameTooltip name="CellTooltipTemplate" mixin="GameTooltipDataMixin" frameStrata="TOOLTIP" clampedToScreen="true" hidden="true" virtual="true">
         <Layers>
             <Layer level="ARTWORK">

--- a/Widgets/TooltipTemplate_Classic.xml
+++ b/Widgets/TooltipTemplate_Classic.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI_shared.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
     <GameTooltip name="CellTooltipTemplate" frameStrata="TOOLTIP" clampedToScreen="true" hidden="true" virtual="true">
         <Layers>
             <Layer level="ARTWORK">


### PR DESCRIPTION
## Summary

Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing the removal of `COMBAT_LOG_EVENT_UNFILTERED`, the introduction of **Secret Values**, blocked addon communications during restricted contexts, and spell/API removals. Bumps Cell to **r275** with Interface **120001**.

## Key Changes

###  Secret Values (12.0.0+)
- **`Utils.lua`**: Add `Cell.isMidnight` detection flag, `F.IsSecretValue()`, `F.IsAuraRestricted()`, `F.IsCooldownRestricted()` utility functions
- **`UnitButton.lua`**: Major dual-path refactor — Midnight uses `UnitHealPredictionCalculator`, `C_CurveUtil.CreateCurve()`, and `StatusBar` overlays for health/prediction/shields; pre-Midnight retains arithmetic-based paths
- **`Appearance.lua`**: IncomingHeal widget uses `SetStatusBarTexture` on Midnight (StatusBar) vs `SetTexture` pre-Midnight (Texture)
- **`Indicator_Defaults.lua`**: Local `DebuffTypeColor` fallback for when the WoW global is removed

###  CLEU Removal
- **`AoEHealing.lua`**: Disabled on Midnight (CLEU unavailable); frame still exists for potential future non-CLEU API
- **`StatusIcon.lua`**: Soulstone/resurrection tracking switches to `UNIT_AURA` + `UNIT_HEALTH` on Midnight
- **`NPCFrame.lua`**: Boss6-8 health/aura tracking switches to unit events on Midnight
- **`DeathReport.lua`**: Full refactor — Midnight uses `UNIT_HEALTH` + `UnitIsDeadOrGhost()` for death detection
- **`UnitButton.lua`**: Removed `CombatLogGetCurrentEventInfo` dependency and `CheckCLEURequired`

###  Comm Restrictions
- **`Comm.lua`**: `IsCommRestricted()` detects encounters/M+/PvP; all `SendCommMessage` calls guarded; pending queue with flush on `ENCOUNTER_END`
- **`Nicknames.lua`**: All nickname sync sends guarded with `F.IsCommRestricted()`

###  Spell & Default Updates (12.0)
- Removed: Engulf, Renew, Power Word: Life, Void Shift, Shadow Covenant, Divine Star, Cloudburst Totem, Minor Cenarion Ward, Premonition of Solace
- Added: Plea (200829, Disc Priest)
- Moved: Prayer of Mending from class-wide to Holy spec only
- Fixed: Shaman Poison dispel node IDs (103609 → 103599)

###  Defensive Nil Guards & Fixes
- **`MainFrame.lua`**: Nil guards for `currentLayoutTable` and `tooltipPoint`
- **`HideBlizzard.lua`**: Guards for `PartyMemberFramePool`, `CompactPartyFrame`, `PartyMemberBackground`
- **`RaidDebuffs.lua`**: Nil guard for encounter journal expansion data
- **`TargetedSpells.lua`**: Skip enemy spell tracking during restricted periods
- **`BuffTracker.lua`**: Guard `GetAuraDataBySpellName` when auras are restricted

###  Infrastructure
- All 22 XML files updated from `FrameXML/UI_shared.xsd` → `Blizzard_SharedXML/UI.xsd`
- **`General.lua`**: Removed `useCleuHealthUpdater` checkbox (CLEU health updater obsolete)
- **`Revise.lua`**: r275 migration removes `useCleuHealthUpdater` from saved variables
- **`Core.lua`**: Version constants bumped to 275, `GetBattlegroundInfo` guard added

### Classic Flavors
No changes to Classic-specific files (`UnitButton_Cata_Wrath.lua`, `UnitButton_Vanilla.lua`, `UnitButton_Mists.lua`, `Custom_Classic.lua`) — Midnight only affects Retail.

## Files Changed (47 files, +1348 / -564)

<details>
<summary>Full file list</summary>

- `Cell.toc` — Interface & version bump
- `Core.lua` — Version constants, BG info guard, testing CVars
- `Revise.lua` — r275 migration
- `Utils.lua` — isMidnight flag, secret value helpers
- `Comm/Comm.lua` — Comm restriction system
- `Comm/Nicknames.lua` — Nickname sync guards
- `Defaults/ClickCasting_DefaultSpells.lua` — Spell removals/additions
- `Defaults/Indicator_DefaultSpells.lua` — Spell & dispel node updates
- `Defaults/Indicator_Defaults.lua` — DebuffTypeColor fallback
- `HideBlizzard.lua` — Party frame nil guards
- `Indicators/Actions.lua` — Audit comments
- `Indicators/AoEHealing.lua` — CLEU guard
- `Indicators/Base.lua` — Secret value comments
- `Indicators/Built-in.lua` — Midnight audit
- `Indicators/Custom.lua` — Midnight audit
- `Indicators/StatusIcon.lua` — UNIT_AURA/UNIT_HEALTH dual-path
- `Indicators/TargetedSpells.lua` — Restriction guard
- `Modules/Appearance/Appearance.lua` — IncomingHeal StatusBar
- `Modules/General/General.lua` — Remove CLEU checkbox
- `Modules/RaidDebuffs/RaidDebuffs.lua` — EJ nil guard
- `RaidFrames/Groups/NPCFrame.lua` — Boss6-8 unit events
- `RaidFrames/MainFrame.lua` — Nil guards
- `RaidFrames/UnitButton.lua` — Major Midnight refactor
- `RaidFrames/UnitButton.xml` — Schema URL
- `Utilities/BuffTracker.lua` — Aura restriction guard
- `Utilities/DeathReport.lua` — UNIT_HEALTH death detection
- 22 XML files — Schema URL updates

</details>

## Testing Notes

Use these CVars to force secret value restrictions on PTR/Beta:
```lua
/run SetCVar("secretCombatRestrictionsForced", 1)
/run SetCVar("secretEncounterRestrictionsForced", 1)
/run SetCVar("secretChallengeModeRestrictionsForced", 1)
/run SetCVar("secretPvPMatchRestrictionsForced", 1)
