### PR TITLE
12.0.5: New .5 Patch API fixes and private aura changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Interface bumped to 120005. Without these fixes Cell showed static white health 
 `UnitHealPredictionCalculator` returns secret-flagged numbers even in normal gameplay. Lua arithmetic and comparisons throw, but C-implemented formatters (`string.format`, `AbbreviateNumbers`, `BreakUpLargeNumbers`) pass secrets through to non-secret strings. Percentages come from calculator curve methods.
 
 - **Health Text**: new `midnightFormatter` table backed by calculator methods, plus `GetMidnightCurves` factory (two reusable `C_CurveUtil` curves for positive and negative percentage scales). `HealthText_SetFormat` stashes format names for lookup; `HealthText_SetValue` takes a new `calc` arg and routes each slot when values are secret. Caller in `RaidFrames/UnitButton.lua` passes the unit's `healthCalculator`.
-- **Power Text**: per-format secret paths. `SetPower_Number` via `string.format("%d", current)`, `SetPower_Number_Short` via `AbbreviateNumbers`. Non-secret paths also moved to `SafeTextWidth` because `GetStringWidth` stays tainted after the FontString held secret text.
+- **Power Text**: `SetPower_Percentage` calls `UnitPowerPercent(unit, nil, true, CurveConstants.ScaleTo100)` (wrapped in `pcall`) to get a plain 0-100 value when Cell's context would otherwise return a secret `UnitPower`. Caller at `UnitButton_UpdatePowerText` passes `self.states.displayedUnit` so the formatter has a unit to query. `SetPower_Number` uses `string.format("%d", current)`, `SetPower_Number_Short` uses `AbbreviateNumbers`. Non-secret paths moved to `SafeTextWidth` because `GetStringWidth` stays tainted after the FontString held secret text.
+- **Power bar**: `UnitButton_UpdatePowerMax` and `UnitButton_UpdatePower` now use native `SetMinMaxValues` and `SetValue` on Midnight unconditionally, bypassing `SmoothStatusBarMixin`. The mixin caches min/max and its per-frame `Clamp()` throws every tick if either value was ever secret, even after the current value is plain. Matches what the health bar already does on Midnight.
 - **`SafeTextWidth` helper**: font-proportional fallback when `GetStringWidth` returns a secret-flagged width. Used by both text indicators' secret paths and their `SetFont` paths.
 - **QuickAssist**: no change; `StatusBar:SetValue` / `:SetMinMaxValues` accept secrets natively.
 
@@ -29,7 +30,7 @@ Interface bumped to 120005. Without these fixes Cell showed static white health 
 
 Health Text: `health`, `health_short`, `health_percent`, `deficit`, `deficit_short`, `deficit_percent`, `shields`, `shields_short`, `healabsorbs`, `healabsorbs_short`. `effective_*` degrades to matching `health_*` (no `GetEffectiveHealth` method). `*_percent` on shields/healabsorbs degrades to short absolute (no matching curve method).
 
-Power Text: `number`, `number-short`. `percentage` removed entirely (no power-side calculator / curve API). Stale `"percentage"` in saved configs falls through to `number-short`.
+Power Text: `number`, `number-short`, `percentage`. Percent uses `UnitPowerPercent` with `CurveConstants.ScaleTo100` and renders correctly even when raw `UnitPower` is secret. Falls back to `AbbreviateNumbers` only if `UnitPowerPercent` is unavailable or the pcall fails.
 
 ### Limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
+# r276-beta: WoW 12.0.5 Compatibility
+
+Interface bumped to 120005. Without these fixes Cell showed static white health bars, missing health/power text, and taint errors in PvP/M+.
+
+## API Updates
+
+- Added required `isContainer = false` to `C_UnitAuras.AddPrivateAuraAnchor` args (new in 12.0.5).
+
+## Secret-Value Guards
+
+12.0.5 decoupled Secret Value restrictions from the aura-restriction context flag, so `F.IsAuraRestricted()` context-guards miss real secrets. Replaced with per-value `F.IsSecretValue` / `issecretvalue` checks at the use site:
+
+- `Indicators/Custom.lua`: `auraInfo.sourceUnit` comparison for the cast-by-me filter.
+- `Indicators/TargetedSpells.lua`: `UnitCastingInfo` / `UnitChannelInfo` returns (`spellId`, timestamps, `texture`).
+- `RaidFrames/UnitButton.lua`: `UnitGUID` comparisons in `UnitButton_OnTick`; `powerMax` in `UnitButton_UpdatePowerStates`.
+- `Utilities/BuffTracker.lua`: LGI cache lookup by GUID.
+- `Utilities/DeathReport.lua`: `reportedDead[guid]` table key.
+
+## Text Indicators on Secret Values
+
+`UnitHealPredictionCalculator` returns secret-flagged numbers even in normal gameplay. Lua arithmetic and comparisons throw, but C-implemented formatters (`string.format`, `AbbreviateNumbers`, `BreakUpLargeNumbers`) pass secrets through to non-secret strings. Percentages come from calculator curve methods.
+
+- **Health Text**: new `midnightFormatter` table backed by calculator methods, plus `GetMidnightCurves` factory (two reusable `C_CurveUtil` curves for positive and negative percentage scales). `HealthText_SetFormat` stashes format names for lookup; `HealthText_SetValue` takes a new `calc` arg and routes each slot when values are secret. Caller in `RaidFrames/UnitButton.lua` passes the unit's `healthCalculator`.
+- **Power Text**: per-format secret paths. `SetPower_Number` via `string.format("%d", current)`, `SetPower_Number_Short` via `AbbreviateNumbers`. Non-secret paths also moved to `SafeTextWidth` because `GetStringWidth` stays tainted after the FontString held secret text.
+- **`SafeTextWidth` helper**: font-proportional fallback when `GetStringWidth` returns a secret-flagged width. Used by both text indicators' secret paths and their `SetFont` paths.
+- **QuickAssist**: no change; `StatusBar:SetValue` / `:SetMinMaxValues` accept secrets natively.
+
+### Supported formats on secret values
+
+Health Text: `health`, `health_short`, `health_percent`, `deficit`, `deficit_short`, `deficit_percent`, `shields`, `shields_short`, `healabsorbs`, `healabsorbs_short`. `effective_*` degrades to matching `health_*` (no `GetEffectiveHealth` method). `*_percent` on shields/healabsorbs degrades to short absolute (no matching curve method).
+
+Power Text: `number`, `number-short`. `percentage` removed entirely (no power-side calculator / curve API). Stale `"percentage"` in saved configs falls through to `number-short`.
+
+### Limitations
+
+- `hideIfEmptyOrFull` is a no-op on secret values (needs comparisons).
+- `effective`-format on health diverges from true effective only when shields or heal absorbs are active.
+
+## Aura Classification
+
+12.0.5 un-secreted `isHelpful`, `isHarmful`, `isRaid`, `isNameplateOnly`, `isFromPlayerOrPlayerPet`. Removed the `issecretvalue(auraInfo.isHelpful)` early-return in `Indicators/Custom.lua` and the classification-secret fallback in `RaidFrames/UnitButton.lua`'s incremental aura fast path.
+
 # r275.5 Added Midnight Raid Debuffs
 
 ## Raid Debuffs
+
 - Added initial Midnight expansion raid debuffs for all 12 instances (6 raids, 6 dungeons) and 41 bosses.
 - Boss ability spell IDs sourced from the Encounter Journal via wago.tools DB2 tables.
 - General (trash mob) debuffs still need to be collected in-game and added in a future update.
@@ -11,6 +54,7 @@
 Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing the removal of `COMBAT_LOG_EVENT_UNFILTERED`, the introduction of Secret Values, blocked addon communications during restricted contexts, and spell/API removals. Interface bumped to 120001.
 
 ## Secret Values (12.0.0+)
+
 - Add `Cell.isMidnight` detection flag and `F.IsSecretValue()`, `F.IsAuraRestricted()`, `F.IsCooldownRestricted()` utility functions
 - Add per-aura `F.IsAuraNonSecret()`, `F.IsSpellAuraNonSecret()`, `F.IsValueNonSecret()` helpers — non-secret (whitelisted) auras now get real countdown timers, source detection, and duration display; secret auras gracefully degrade
 - UnitButton: major dual-path refactor — Midnight uses `UnitHealPredictionCalculator`, `C_CurveUtil.CreateCurve()`, and StatusBar overlays for health/prediction/shields; pre-Midnight retains arithmetic-based paths
@@ -19,6 +63,7 @@ Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing t
 - Per-field `F.IsValueNonSecret()` guards before every arithmetic operation on temporal aura fields (`expirationTime`, `duration`, `applications`, and cached `old*` variants)
 
 ## CLEU Removal
+
 - AoEHealing: disabled on Midnight (CLEU unavailable); frame still exists for potential future non-CLEU API
 - StatusIcon: soulstone/resurrection tracking switches to `UNIT_AURA` + `UNIT_HEALTH` on Midnight
 - NPCFrame: boss6-8 health/aura tracking switches to unit events on Midnight
@@ -28,23 +73,27 @@ Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing t
 - Revise: r275 migration removes `useCleuHealthUpdater` from saved variables
 
 ## Comm Restrictions
+
 - Comm: `IsCommRestricted()` detects encounters/M+/PvP; all `SendCommMessage` calls guarded; pending queue with flush on `ENCOUNTER_END`
 - Nicknames: all nickname sync sends guarded with `F.IsCommRestricted()`
 
 ## Heal Prediction & Health Bar Fixes
+
 - Created a dedicated `healPredictionCalculator` separate from the shared `healthCalculator` — the heal prediction function's `SetIncomingHealClampMode(0)` and `SetIncomingHealOverflowPercent(1.0)` were persisting on the shared calculator and corrupting health/absorb reads
 - Incoming heal bar is now a StatusBar (instead of Texture) anchored to the health fill texture edge
 - Fixed health bar loss color stuck on white/full-health — `self.states.healthPercent` was never set on the Midnight path; now populated from `calculator:GetCurrentHealthPercent()` with a secret-safe fallback
 - Dispels now show correctly because `HandleDebuff` completes to the dispel detection code (string/boolean fields, not temporal arithmetic)
 
 ## Spell & Default Updates
+
 - Removed: Engulf, Renew, Power Word: Life, Void Shift, Shadow Covenant, Divine Star, Cloudburst Totem, Minor Cenarion Ward, Premonition of Solace
 - Added: Plea (200829, Disc Priest)
 - Added missing healing spells to default indicator list (Evoker, Monk, Paladin, Priest)
 - Moved: Prayer of Mending from class-wide to Holy spec only
-- Fixed: Shaman Poison dispel node IDs (103609 → 103599)
+- Fixed: Shaman Poison dispel node IDs (103609 -> 103599)
 
 ## Defensive Nil Guards & Fixes
+
 - MainFrame: nil guards for `currentLayoutTable` and `tooltipPoint`
 - HideBlizzard: guards for `PartyMemberFramePool`, `CompactPartyFrame`, `PartyMemberBackground`
 - RaidDebuffs: nil guard for encounter journal expansion data
@@ -55,7 +104,8 @@ Comprehensive compatibility update for WoW Patch 12.0.0 (Midnight), addressing t
 - Appearance: ticker nil guard in preview `OnHide`
 
 ## Infrastructure
-- All 22 XML files updated from `FrameXML/UI_shared.xsd` → `Blizzard_SharedXML/UI.xsd`
+
+- All 22 XML files updated from `FrameXML/UI_shared.xsd` -> `Blizzard_SharedXML/UI.xsd`
 - Core: version constants bumped to 275, `GetBattlegroundInfo` guard added
 
 ---

--- a/Cell.toc
+++ b/Cell.toc
@@ -1,6 +1,6 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: Cell
-## Version: r275-beta
+## Version: r276-beta
 ## Author: enderneko
 ## X-Flavor: Mainline
 ## SavedVariables: CellDB, CellDBBackup

--- a/Cell_TBC.toc
+++ b/Cell_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: Cell
 ## Version: r275-beta
 ## Author: enderneko
-## X-Flavor: Vanilla
+## X-Flavor: TBC
 ## SavedVariables: CellDB, CellDBBackup
 ## SavedVariablesPerCharacter: CellCharacterDB
 

--- a/Cell_Wrath.toc
+++ b/Cell_Wrath.toc
@@ -1,4 +1,4 @@
-## Interface: 38000
+## Interface: 30405
 ## Title: Cell
 ## Version: r275-beta
 ## Author: enderneko

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1558,14 +1558,20 @@ local function HealthText_SetFormat(self, format)
 end
 
 local function HealthText_SetValue(self, health, maxHealth, shields, healAbsorbs)
-    -- On Midnight 12.0.0+, health/maxHealth may be secret values in restricted contexts.
-    -- Arithmetic (/, *, -, comparison) on secret values causes errors.
-    -- AbbreviateNumbers() and FontString:SetText() accept secret values safely.
-    -- DO NOT divide, multiply, or compare secret values.
-    if Cell.isMidnight and F.IsAuraRestricted and F.IsAuraRestricted() then
+    -- 12.0.5+: health/maxHealth can be secret in restricted contexts (pets, arena units)
+    -- independently of IsAuraRestricted. Guard per-value. AbbreviateNumbers and SetText
+    -- are the only operations that accept secrets safely — no arithmetic, no comparison.
+    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(health) or F.IsSecretValue(maxHealth)) then
+        -- Midnight's HealPredictionCalculator returns secret-wrapped values even in normal
+        -- gameplay. AbbreviateNumbers and SetText accept secrets and render the string
+        -- correctly at the C++ layer (e.g. "430K"). What we can't do is query GetStringWidth()
+        -- and feed it back to SetWidth — that returns a secret-tainted width which SetWidth
+        -- rejects. Fall back to a font-size-proportional width so the parent frame has
+        -- nonzero width for layout; the FontString itself renders at its natural pixel size.
         local healthStr = AbbreviateNumbers and AbbreviateNumbers(health) or tostring(health)
         self.text:SetText(healthStr)
-        self:SetWidth(self.text:GetStringWidth())
+        local _, fontSize = self.text:GetFont()
+        self:SetWidth(fontSize and fontSize * 4 or 60)
         return
     end
 
@@ -1654,7 +1660,23 @@ end
 -------------------------------------------------
 -- power text
 -------------------------------------------------
+-- 12.0.5+: power can be a secret-wrapped number on restricted units (arena pets etc.).
+-- When secret, we can't compare (`== 0`, `== max`), arithmetic (`current/max*100`), or
+-- measure the rendered string (`GetStringWidth` returns a tainted width). Route to
+-- AbbreviateNumbers + SetText (both C++-implemented, accept secrets) and set a
+-- font-proportional width so the parent frame participates in layout.
+local function SetPower_Secret(self, current)
+    local text = AbbreviateNumbers and AbbreviateNumbers(current) or tostring(current)
+    self.text:SetText(text)
+    local _, fontSize = self.text:GetFont()
+    self:SetWidth(fontSize and fontSize * 4 or 60)
+    self:Show()
+end
+
 local function SetPower_Percentage(self, current, max)
+    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
+        return SetPower_Secret(self, current)
+    end
     if self.hideIfEmptyOrFull and (current == 0 or current == max) then
         self:Hide()
     else
@@ -1665,6 +1687,9 @@ local function SetPower_Percentage(self, current, max)
 end
 
 local function SetPower_Number(self, current, max)
+    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
+        return SetPower_Secret(self, current)
+    end
     if self.hideIfEmptyOrFull and (current == 0 or current == max) then
         self:Hide()
     else
@@ -1675,6 +1700,9 @@ local function SetPower_Number(self, current, max)
 end
 
 local function SetPower_Number_Short(self, current, max)
+    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
+        return SetPower_Secret(self, current)
+    end
     if self.hideIfEmptyOrFull and (current == 0 or current == max) then
         self:Hide()
     else

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1746,9 +1746,34 @@ local function SetPower_SecretWidth(self)
     self:Show()
 end
 
--- Power percentage removed in 12.0.5: no power calculator / curve to derive a percentage
--- on a secret. If Blizzard adds one, restore `SetPower_Percentage` and the dropdown entry
--- in Widgets_IndicatorSettings.lua.
+local function SetPower_Percentage(self, current, max, unit)
+    -- Preferred path on Midnight: UnitPowerPercent(unit, powerType, useCurve, curve) returns
+    -- a plain 0-100 number directly from the C layer, bypassing the secret-value restriction
+    -- on UnitPower. pcall because the API can throw in some restricted contexts.
+    if unit and Cell.isMidnight and UnitPowerPercent and CurveConstants and CurveConstants.ScaleTo100 then
+        local ok, pct = pcall(UnitPowerPercent, unit, nil, true, CurveConstants.ScaleTo100)
+        if ok and type(pct) == "number" then
+            local _, fontSize = self.text:GetFont()
+            self.text:SetFormattedText("%d%%", pct)
+            self:SetWidth(SafeTextWidth(self.text, fontSize))
+            self:Show()
+            return
+        end
+    end
+    -- Fallback when the UnitPowerPercent path isn't available or fails: abbreviated if secret, else arithmetic.
+    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
+        self.text:SetText(AbbreviateNumbers and AbbreviateNumbers(current) or tostring(current))
+        return SetPower_SecretWidth(self)
+    end
+    if self.hideIfEmptyOrFull and (current == 0 or current == max) then
+        self:Hide()
+    else
+        local _, fontSize = self.text:GetFont()
+        self.text:SetFormattedText("%d%%", current/max*100)
+        self:SetWidth(SafeTextWidth(self.text, fontSize))
+        self:Show()
+    end
+end
 
 local function SetPower_Number(self, current, max)
     if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
@@ -1819,8 +1844,9 @@ local function PowerText_SetPoint(self, point, relativeTo, relativePoint, x, y)
 end
 
 local function PowerText_SetFormat(self, format)
-    -- Stale "percentage" configs fall through to number-short.
-    if format == "number" then
+    if format == "percentage" then
+        self.SetValue = SetPower_Percentage
+    elseif format == "number" then
         self.SetValue = SetPower_Number
     else
         self.SetValue = SetPower_Number_Short

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1543,11 +1543,86 @@ local function BuildPattern(config)
     end
 end
 
+-- Fallback width when GetStringWidth returns a secret-tainted value (rejected by SetWidth).
+local function SafeTextWidth(fontString, fontSize)
+    local w = fontString:GetStringWidth()
+    if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(w) then
+        return fontSize and fontSize * 4 or 60
+    end
+    return w
+end
+
+-- 12.0.5 secret-safe formatters. HealPredictionCalculator returns secret numbers even
+-- in normal gameplay; Lua arithmetic and comparisons throw. Values go through calculator
+-- methods and C-implemented pass-throughs (string.format, AbbreviateNumbers,
+-- BreakUpLargeNumbers). effective_* and *_percent variants without a calc method fall
+-- back to the closest supported format.
+
+local _pct01to100, _pct01toNeg100
+local function GetMidnightCurves()
+    if _pct01to100 then return _pct01to100, _pct01toNeg100 end
+    if not C_CurveUtil then return nil, nil end
+    _pct01to100 = C_CurveUtil.CreateCurve()
+    _pct01to100:AddPoint(0.0, 0.0)
+    _pct01to100:AddPoint(1.0, 100.0)
+    _pct01toNeg100 = C_CurveUtil.CreateCurve()
+    _pct01toNeg100:AddPoint(0.0, 0.0)
+    _pct01toNeg100:AddPoint(1.0, -100.0)
+    return _pct01to100, _pct01toNeg100
+end
+
+local midnightFormatter = {
+    none = function() return "" end,
+
+    health = function(pattern, calc) return pattern:format(calc:GetCurrentHealth()) end,
+    health_short = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetCurrentHealth())) end,
+    health_percent = function(pattern, calc)
+        local pos = GetMidnightCurves()
+        return pattern:format(calc:EvaluateCurrentHealthPercent(pos))
+    end,
+
+    -- Sign is embedded in the string (can't negate a secret).
+    deficit = function(pattern, calc) return pattern:format("-"..BreakUpLargeNumbers(calc:GetMissingHealth())) end,
+    deficit_short = function(pattern, calc) return pattern:format("-"..AbbreviateNumbers(calc:GetMissingHealth())) end,
+    deficit_percent = function(pattern, calc)
+        local _, neg = GetMidnightCurves()
+        return pattern:format(calc:EvaluateMissingHealthPercent(neg))
+    end,
+
+    -- effective_* degrades to health_* (no calc method for effective health).
+    effective = function(pattern, calc) return pattern:format(calc:GetCurrentHealth()) end,
+    effective_short = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetCurrentHealth())) end,
+    effective_percent = function(pattern, calc)
+        local pos = GetMidnightCurves()
+        return pattern:format(calc:EvaluateCurrentHealthPercent(pos))
+    end,
+
+    shields = function(pattern, calc) return pattern:format(calc:GetTotalDamageAbsorbs()) end,
+    shields_short = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetTotalDamageAbsorbs())) end,
+    -- *_percent variants degrade to short absolute (no calc method for absorbs percent).
+    shields_percent = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetTotalDamageAbsorbs())) end,
+
+    healabsorbs = function(pattern, calc) return pattern:format(calc:GetTotalHealAbsorbs()) end,
+    healabsorbs_short = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetTotalHealAbsorbs())) end,
+    healabsorbs_percent = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetTotalHealAbsorbs())) end,
+}
+
 local function HealthText_SetFormat(self, format)
-    self.GetHealth1 = formatter[format.health1.format:gsub("_no_sign$", "")]
-    self.GetHealth2 = formatter[format.health2.format:gsub("_no_sign$", "")]
-    self.GetShields = formatter[format.shields.format:gsub("_no_sign$", "")]
-    self.GetHealAbsorbs = formatter[format.healAbsorbs.format:gsub("_no_sign$", "")]
+    local h1 = format.health1.format:gsub("_no_sign$", "")
+    local h2 = format.health2.format:gsub("_no_sign$", "")
+    local sh = format.shields.format:gsub("_no_sign$", "")
+    local ha = format.healAbsorbs.format:gsub("_no_sign$", "")
+
+    self.GetHealth1 = formatter[h1]
+    self.GetHealth2 = formatter[h2]
+    self.GetShields = formatter[sh]
+    self.GetHealAbsorbs = formatter[ha]
+
+    -- Names kept for the Midnight secret path to look up a different formatter table.
+    self._health1_format = h1
+    self._health2_format = h2
+    self._shields_format = sh
+    self._healAbsorbs_format = ha
 
     self.health1 = BuildPattern(format.health1)
     self.health1_hideIfEmptyOrFull = format.health1.hideIfEmptyOrFull
@@ -1557,21 +1632,20 @@ local function HealthText_SetFormat(self, format)
     self.healAbsorbs = BuildPattern(format.healAbsorbs)
 end
 
-local function HealthText_SetValue(self, health, maxHealth, shields, healAbsorbs)
-    -- 12.0.5+: health/maxHealth can be secret in restricted contexts (pets, arena units)
-    -- independently of IsAuraRestricted. Guard per-value. AbbreviateNumbers and SetText
-    -- are the only operations that accept secrets safely — no arithmetic, no comparison.
-    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(health) or F.IsSecretValue(maxHealth)) then
-        -- Midnight's HealPredictionCalculator returns secret-wrapped values even in normal
-        -- gameplay. AbbreviateNumbers and SetText accept secrets and render the string
-        -- correctly at the C++ layer (e.g. "430K"). What we can't do is query GetStringWidth()
-        -- and feed it back to SetWidth — that returns a secret-tainted width which SetWidth
-        -- rejects. Fall back to a font-size-proportional width so the parent frame has
-        -- nonzero width for layout; the FontString itself renders at its natural pixel size.
-        local healthStr = AbbreviateNumbers and AbbreviateNumbers(health) or tostring(health)
-        self.text:SetText(healthStr)
+local function HealthText_SetValue(self, health, maxHealth, shields, healAbsorbs, calc)
+    -- Secret path routes the user's format through calculator methods; calc is the unit's HealPredictionCalculator.
+    if Cell.isMidnight and calc and F.IsSecretValue and (F.IsSecretValue(health) or F.IsSecretValue(maxHealth)) then
+        local f1 = midnightFormatter[self._health1_format or "none"] or midnightFormatter.none
+        local f2 = midnightFormatter[self._health2_format or "none"] or midnightFormatter.none
+        local fs = midnightFormatter[self._shields_format or "none"] or midnightFormatter.none
+        local fh = midnightFormatter[self._healAbsorbs_format or "none"] or midnightFormatter.none
+        self.text:SetFormattedText("%s%s%s%s",
+            f1(self.health1, calc),
+            f2(self.health2, calc),
+            fs(self.shields, calc),
+            fh(self.healAbsorbs, calc))
         local _, fontSize = self.text:GetFont()
-        self:SetWidth(fontSize and fontSize * 4 or 60)
+        self:SetWidth(SafeTextWidth(self.text, fontSize))
         return
     end
 
@@ -1583,17 +1657,6 @@ local function HealthText_SetValue(self, health, maxHealth, shields, healAbsorbs
         self.GetShields(self.shields, health, maxHealth, shields, healAbsorbs),
         self.GetHealAbsorbs(self.healAbsorbs, health, maxHealth, shields, healAbsorbs))
     self:SetWidth(self.text:GetStringWidth())
-end
-
--- Shared helper: compute a safe width for a FontString that may currently hold
--- secret-derived text. GetStringWidth taints when text is secret, which would be
--- rejected by SetWidth/SetSize. Returns a font-size-proportional fallback in that case.
-local function SafeTextWidth(fontString, fontSize)
-    local w = fontString:GetStringWidth()
-    if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(w) then
-        return fontSize and fontSize * 4 or 60
-    end
-    return w
 end
 
 local function HealthText_SetFont(self, font, size, outline, shadow)
@@ -1671,54 +1734,48 @@ end
 -------------------------------------------------
 -- power text
 -------------------------------------------------
--- 12.0.5+: power can be a secret-wrapped number on restricted units (arena pets etc.).
--- When secret, we can't compare (`== 0`, `== max`), arithmetic (`current/max*100`), or
--- measure the rendered string (`GetStringWidth` returns a tainted width). Route to
--- AbbreviateNumbers + SetText (both C++-implemented, accept secrets) and set a
--- font-proportional width so the parent frame participates in layout.
-local function SetPower_Secret(self, current)
-    local text = AbbreviateNumbers and AbbreviateNumbers(current) or tostring(current)
-    self.text:SetText(text)
+-- Power values come back secret from within Cell's tainted execution context (no
+-- power-side calculator exists). hideIfEmptyOrFull is a no-op in the secret path
+-- because it needs comparisons. The non-secret paths use SafeTextWidth because a
+-- FontString that ever held secret text returns a secret GetStringWidth thereafter.
+
+local function SetPower_SecretWidth(self)
     local _, fontSize = self.text:GetFont()
     self:SetWidth(fontSize and fontSize * 4 or 60)
     self:Show()
 end
 
-local function SetPower_Percentage(self, current, max)
-    if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
-        return SetPower_Secret(self, current)
-    end
-    if self.hideIfEmptyOrFull and (current == 0 or current == max) then
-        self:Hide()
-    else
-        self.text:SetFormattedText("%d%%", current/max*100)
-        self:SetWidth(self.text:GetStringWidth())
-        self:Show()
-    end
-end
+-- Power percentage removed in 12.0.5: no power calculator / curve to derive a percentage
+-- on a secret. If Blizzard adds one, restore `SetPower_Percentage` and the dropdown entry
+-- in Widgets_IndicatorSettings.lua.
 
 local function SetPower_Number(self, current, max)
     if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
-        return SetPower_Secret(self, current)
+        self.text:SetText(string.format("%d", current))
+        return SetPower_SecretWidth(self)
     end
     if self.hideIfEmptyOrFull and (current == 0 or current == max) then
         self:Hide()
     else
+        local _, fontSize = self.text:GetFont()
         self.text:SetText(current)
-        self:SetWidth(self.text:GetStringWidth())
+        self:SetWidth(SafeTextWidth(self.text, fontSize))
         self:Show()
     end
 end
 
 local function SetPower_Number_Short(self, current, max)
     if Cell.isMidnight and F.IsSecretValue and (F.IsSecretValue(current) or F.IsSecretValue(max)) then
-        return SetPower_Secret(self, current)
+        -- F.FormatNumber does comparisons that would throw on secrets.
+        self.text:SetText(AbbreviateNumbers and AbbreviateNumbers(current) or tostring(current))
+        return SetPower_SecretWidth(self)
     end
     if self.hideIfEmptyOrFull and (current == 0 or current == max) then
         self:Hide()
     else
+        local _, fontSize = self.text:GetFont()
         self.text:SetText(F.FormatNumber(current))
-        self:SetWidth(self.text:GetStringWidth())
+        self:SetWidth(SafeTextWidth(self.text, fontSize))
         self:Show()
     end
 end
@@ -1761,11 +1818,10 @@ local function PowerText_SetPoint(self, point, relativeTo, relativePoint, x, y)
 end
 
 local function PowerText_SetFormat(self, format)
-    if format == "percentage" then
-        self.SetValue = SetPower_Percentage
-    elseif format == "number" then
+    -- Stale "percentage" configs fall through to number-short.
+    if format == "number" then
         self.SetValue = SetPower_Number
-    elseif format == "number-short" then
+    else
         self.SetValue = SetPower_Number_Short
     end
 end

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -973,6 +973,7 @@ local function PrivateAuras_UpdatePrivateAuraAnchor(self, unit)
             unitToken = unit,
             auraIndex = 1,
             parent = self,
+            isContainer = false,
             showCountdownFrame = _showCountdownFrame,
             showCountdownNumbers = _showCountdownNumbers,
             iconInfo = {

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1576,9 +1576,10 @@ local midnightFormatter = {
 
     health = function(pattern, calc) return pattern:format(calc:GetCurrentHealth()) end,
     health_short = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetCurrentHealth())) end,
+    -- Percent formatters round via %.0f since F.Round would do arithmetic on a secret.
     health_percent = function(pattern, calc)
         local pos = GetMidnightCurves()
-        return pattern:format(calc:EvaluateCurrentHealthPercent(pos))
+        return pattern:format(string.format("%.0f", calc:EvaluateCurrentHealthPercent(pos)))
     end,
 
     -- Sign is embedded in the string (can't negate a secret).
@@ -1586,7 +1587,7 @@ local midnightFormatter = {
     deficit_short = function(pattern, calc) return pattern:format("-"..AbbreviateNumbers(calc:GetMissingHealth())) end,
     deficit_percent = function(pattern, calc)
         local _, neg = GetMidnightCurves()
-        return pattern:format(calc:EvaluateMissingHealthPercent(neg))
+        return pattern:format(string.format("%.0f", calc:EvaluateMissingHealthPercent(neg)))
     end,
 
     -- effective_* degrades to health_* (no calc method for effective health).
@@ -1594,7 +1595,7 @@ local midnightFormatter = {
     effective_short = function(pattern, calc) return pattern:format(AbbreviateNumbers(calc:GetCurrentHealth())) end,
     effective_percent = function(pattern, calc)
         local pos = GetMidnightCurves()
-        return pattern:format(calc:EvaluateCurrentHealthPercent(pos))
+        return pattern:format(string.format("%.0f", calc:EvaluateCurrentHealthPercent(pos)))
     end,
 
     shields = function(pattern, calc) return pattern:format(calc:GetTotalDamageAbsorbs()) end,

--- a/Indicators/Built-in.lua
+++ b/Indicators/Built-in.lua
@@ -1585,6 +1585,17 @@ local function HealthText_SetValue(self, health, maxHealth, shields, healAbsorbs
     self:SetWidth(self.text:GetStringWidth())
 end
 
+-- Shared helper: compute a safe width for a FontString that may currently hold
+-- secret-derived text. GetStringWidth taints when text is secret, which would be
+-- rejected by SetWidth/SetSize. Returns a font-size-proportional fallback in that case.
+local function SafeTextWidth(fontString, fontSize)
+    local w = fontString:GetStringWidth()
+    if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(w) then
+        return fontSize and fontSize * 4 or 60
+    end
+    return w
+end
+
 local function HealthText_SetFont(self, font, size, outline, shadow)
     font = F.GetFont(font)
 
@@ -1607,7 +1618,7 @@ local function HealthText_SetFont(self, font, size, outline, shadow)
         self.text:SetShadowColor(0, 0, 0, 0)
     end
 
-    self:SetSize(self.text:GetStringWidth(), size)
+    self:SetSize(SafeTextWidth(self.text, size), size)
 end
 
 local function HealthText_SetPoint(self, point, relativeTo, relativePoint, x, y)
@@ -1734,7 +1745,7 @@ local function PowerText_SetFont(self, font, size, outline, shadow)
         self.text:SetShadowColor(0, 0, 0, 0)
     end
 
-    self:SetSize(self.text:GetStringWidth(), size)
+    self:SetSize(SafeTextWidth(self.text, size), size)
 end
 
 local function PowerText_SetPoint(self, point, relativeTo, relativePoint, x, y)

--- a/Indicators/Custom.lua
+++ b/Indicators/Custom.lua
@@ -255,7 +255,6 @@ end
 function I.UpdateCustomIndicators(unitButton, auraInfo)
     local unit = unitButton.states.displayedUnit
 
-    -- 12.0.5+: isHelpful/isHarmful are no longer secret, so classification is always safe.
     local auraType = auraInfo.isHelpful and "buff" or "debuff"
     local icon = auraInfo.icon
     -- Midnight 12.0.0+: dispelName may be secret; sanitize to avoid table-key/comparison crashes downstream
@@ -271,8 +270,7 @@ function I.UpdateCustomIndicators(unitButton, auraInfo)
         start = 0
         duration = 0
     end
-    -- sourceUnit remains secret on restricted auras in 12.0.5; comparing it would taint execution.
-    -- When secret, default to false (the filter treats the aura as not-cast-by-me).
+    -- sourceUnit is secret on restricted auras; castByMe defaults to false when unreadable.
     local castByMe = false
     if F.IsValueNonSecret(auraInfo.sourceUnit) then
         castByMe = auraInfo.sourceUnit == "player" or auraInfo.sourceUnit == "pet"

--- a/Indicators/Custom.lua
+++ b/Indicators/Custom.lua
@@ -255,10 +255,7 @@ end
 function I.UpdateCustomIndicators(unitButton, auraInfo)
     local unit = unitButton.states.displayedUnit
 
-    -- Midnight 12.0.0+: bail only if aura type (isHelpful) is secret — we need it to classify buff/debuff.
-    -- spellId may still be secret for some auras even with hotfix; don't bail on spellId.
-    if issecretvalue and issecretvalue(auraInfo.isHelpful) then return end
-
+    -- 12.0.5+: isHelpful/isHarmful are no longer secret, so classification is always safe.
     local auraType = auraInfo.isHelpful and "buff" or "debuff"
     local icon = auraInfo.icon
     -- Midnight 12.0.0+: dispelName may be secret; sanitize to avoid table-key/comparison crashes downstream
@@ -274,7 +271,12 @@ function I.UpdateCustomIndicators(unitButton, auraInfo)
         start = 0
         duration = 0
     end
-    local castByMe = auraInfo.sourceUnit == "player" or auraInfo.sourceUnit == "pet"
+    -- sourceUnit remains secret on restricted auras in 12.0.5; comparing it would taint execution.
+    -- When secret, default to false (the filter treats the aura as not-cast-by-me).
+    local castByMe = false
+    if F.IsValueNonSecret(auraInfo.sourceUnit) then
+        castByMe = auraInfo.sourceUnit == "player" or auraInfo.sourceUnit == "pet"
+    end
 
     -- check Bleed
     if auraInfo.isHarmful then

--- a/Indicators/TargetedSpells.lua
+++ b/Indicators/TargetedSpells.lua
@@ -176,9 +176,8 @@ local function CheckUnitCast(sourceUnit, isRecheck)
 
     -- print(sourceUnit, name, spellId)
 
-    -- 12.0.5+: enemy UnitCastingInfo fields can be secret even outside aura-restricted contexts
-    -- (IsAuraRestricted covers auras, not casts). A secret spellId cannot be used as a table key,
-    -- and secret timestamps cannot be arithmeticked. Bail if any critical field is secret.
+    -- Enemy UnitCastingInfo fields can be secret independently of IsAuraRestricted.
+    -- Bail before we use any as a table key or in arithmetic.
     if Cell.isMidnight and issecretvalue then
         if issecretvalue(spellId) or issecretvalue(startTimeMS) or issecretvalue(endTimeMS) or issecretvalue(texture) then
             return

--- a/Indicators/TargetedSpells.lua
+++ b/Indicators/TargetedSpells.lua
@@ -176,6 +176,15 @@ local function CheckUnitCast(sourceUnit, isRecheck)
 
     -- print(sourceUnit, name, spellId)
 
+    -- 12.0.5+: enemy UnitCastingInfo fields can be secret even outside aura-restricted contexts
+    -- (IsAuraRestricted covers auras, not casts). A secret spellId cannot be used as a table key,
+    -- and secret timestamps cannot be arithmeticked. Bail if any critical field is secret.
+    if Cell.isMidnight and issecretvalue then
+        if issecretvalue(spellId) or issecretvalue(startTimeMS) or issecretvalue(endTimeMS) or issecretvalue(texture) then
+            return
+        end
+    end
+
     if spellId and (Cell.vars.targetedSpellsList[spellId] or showAllSpells) then
         if casts[sourceGUID] then
             casts[sourceGUID]["startTime"] = startTimeMS/1000

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -2683,7 +2683,13 @@ local function UnitButton_UpdateThreatBar(self)
     local _, status, scaledPercentage, rawPercentage = UnitDetailedThreatSituation(unit, "target")
     if status then
         self.indicators.aggroBar:Show()
-        self.indicators.aggroBar:SetSmoothedValue(scaledPercentage)
+        -- SetSmoothedValue is a Lua mixin whose Clamp() would throw every tick on a secret percentage.
+        -- Fall back to native SetValue when the threat percent is secret.
+        if Cell.isMidnight and F.IsValueNonSecret and not F.IsValueNonSecret(scaledPercentage) then
+            self.indicators.aggroBar:SetValue(scaledPercentage)
+        else
+            self.indicators.aggroBar:SetSmoothedValue(scaledPercentage)
+        end
         self.indicators.aggroBar:SetStatusBarColor(GetThreatStatusColor(status))
     else
         self.indicators.aggroBar:Hide()

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -2269,10 +2269,9 @@ UnitButton_UpdatePowerText = function(self)
     if not self._shouldShowPowerText then return end
 
     if self.states.powerMax and self.states.power and not self.states.isDeadOrGhost then
-        -- On Midnight, power and powerMax may be secret values (Midnight 12.0.0+)
-        -- SetValue uses string.format/AbbreviateNumbers which accept secrets â†’ FontString:SetText accepts secrets
-        -- Secret handling is in the powerText indicator's SetValue method (Indicators/Base.lua) â€” Phase 8 follow-up
-        self.indicators.powerText:SetValue(self.states.power, self.states.powerMax)
+        -- Pass the unit so the percent formatter can use UnitPowerPercent(unit, nil, true, curve)
+        -- which returns a plain 0-100 value in contexts where raw UnitPower would be secret.
+        self.indicators.powerText:SetValue(self.states.power, self.states.powerMax, self.states.displayedUnit)
     else
         self.indicators.powerText:Hide()
     end
@@ -2296,10 +2295,10 @@ end
 UnitButton_UpdatePowerMax = function(self)
     if not (self._shouldShowPowerBar and self.states.powerMax) then return end
 
-    -- powerMax may be secret on Midnight 12.0.0+ for some units.
-    -- SetMinMaxSmoothedValue is a Lua mixin that does arithmetic (Clamp) â€" fails on secrets.
-    -- SetMinMaxValues is native C API that accepts secrets. Use it as fallback on Midnight.
-    if barAnimationType == "Smooth" and F.IsValueNonSecret(self.states.powerMax) then
+    -- Force native SetMinMaxValues on Midnight. SmoothStatusBarMixin caches min/max
+    -- internally and its per-frame Clamp() throws if either value was ever secret,
+    -- so the Smooth path is unsafe even when the current powerMax happens to be plain.
+    if barAnimationType == "Smooth" and not Cell.isMidnight then
         self.widgets.powerBar:SetMinMaxSmoothedValue(0, self.states.powerMax)
     else
         self.widgets.powerBar:SetMinMaxValues(0, self.states.powerMax)
@@ -2309,10 +2308,9 @@ end
 UnitButton_UpdatePower = function(self)
     if not (self._shouldShowPowerBar and self.states.power) then return end
 
-    -- self.states.power may be a secret value on Midnight 12.0.0+
-    -- SetBarValue maps to SetSmoothedValue in Smooth mode, which does Lua Clamp and fails on secrets.
-    -- Use native SetValue on Midnight when power is secret.
-    if Cell.isMidnight and not F.IsValueNonSecret(self.states.power) then
+    -- Same reason as UpdatePowerMax: always use native SetValue on Midnight to stay
+    -- off the SmoothStatusBar tick, mirroring what the health bar does at line 2395.
+    if Cell.isMidnight then
         self.widgets.powerBar:SetValue(self.states.power)
     else
         self.widgets.powerBar:SetBarValue(self.states.power)

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1755,9 +1755,7 @@ UnitButton_UpdateAuras = function(self, updateInfo)
         UnitButton_UpdateBuffs(self, true)
         UnitButton_UpdateDebuffs(self, true)
     else
-        -- 12.0.5+: isHelpful/isHarmful are guaranteed non-secret, so classification is always safe.
-        -- Temporal fields (expirationTime, duration, applications, sourceUnit) may still be secret;
-        -- per-aura F.IsAuraNonSecret / F.IsValueNonSecret guards below handle those on read.
+        -- Classification via isHelpful/isHarmful is always safe; temporal fields are guarded at read sites.
         local buffsChanged, debuffsChanged
         wipe(self._missing_auras)
 
@@ -1890,8 +1888,8 @@ local function UnitButton_UpdateHealthStates(self, diff)
             local maxHealth = calc:GetMaximumHealth()
             local totalAbsorbs = calc:GetTotalDamageAbsorbs()
             local healAbsorbs = calc:GetTotalHealAbsorbs()
-            -- SetValue accepts secret values
-            self.indicators.healthText:SetValue(health, maxHealth, totalAbsorbs, healAbsorbs)
+            -- Pass calc so SetValue can route through Midnight curve/format methods when values are secret.
+            self.indicators.healthText:SetValue(health, maxHealth, totalAbsorbs, healAbsorbs, calc)
             self.indicators.healthText:Show()
         else
             self.indicators.healthText:Hide()
@@ -1960,8 +1958,7 @@ local function UnitButton_UpdatePowerStates(self)
 
     self.states.power = UnitPower(unit)
     self.states.powerMax = UnitPowerMax(unit)
-    -- 12.0.5+: UnitPower/UnitPowerMax can return secrets in restricted contexts (arena pets,
-    -- enemy PvP units). Guard per-value — IsAuraRestricted is aura-scoped and misses these.
+    -- powerMax can be secret on arena pets / enemy PvP; IsAuraRestricted misses this.
     if not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(self.states.powerMax)) then
         if self.states.powerMax <= 0 then self.states.powerMax = 1 end
     end
@@ -3369,9 +3366,8 @@ local function UnitButton_OnTick(self)
 
         if self.states.unit and self.states.displayedUnit then
             local displayedGuid = UnitGUID(self.states.displayedUnit)
-            -- 12.0.5+: UnitGUID can return a secret in restricted contexts. Comparing a secret
-            -- against a plaintext cached GUID taints; skip the change-detection this tick.
-            -- The secure header still drives real unit-change events, so this is safe.
+            -- Secret GUID can't be compared against the cached plaintext; skip change detection this tick.
+            -- Real unit changes still come through the secure header.
             local displayedGuidReadable = not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(displayedGuid))
             if displayedGuidReadable and displayedGuid ~= self.__displayedGuid then
                 -- NOTE: displayed unit entity changed

--- a/RaidFrames/UnitButton.lua
+++ b/RaidFrames/UnitButton.lua
@@ -1755,30 +1755,21 @@ UnitButton_UpdateAuras = function(self, updateInfo)
         UnitButton_UpdateBuffs(self, true)
         UnitButton_UpdateDebuffs(self, true)
     else
-        -- Midnight 12.0.0+: some aura fields may still be secret. Per-aura checks in
-        -- HandleBuff/HandleDebuff handle this. We no longer force full update for ALL
-        -- Midnight aura events â€” only fall back to full update if we encounter secret
-        -- isHelpful/isHarmful fields in addedAuras that prevent classification.
+        -- 12.0.5+: isHelpful/isHarmful are guaranteed non-secret, so classification is always safe.
+        -- Temporal fields (expirationTime, duration, applications, sourceUnit) may still be secret;
+        -- per-aura F.IsAuraNonSecret / F.IsValueNonSecret guards below handle those on read.
         local buffsChanged, debuffsChanged
         wipe(self._missing_auras)
 
         if updateInfo.addedAuras then
             for _, aura in next, updateInfo.addedAuras do
-                if F.IsAuraNonSecret(aura) then
-                    if aura.isHelpful then
-                        buffsChanged = true
-                        self._buffs_cache[aura.auraInstanceID] = aura
-                    end
-                    if aura.isHarmful then
-                        debuffsChanged = true
-                        self._debuffs_cache[aura.auraInstanceID] = aura
-                    end
-                else
-                    -- Secret aura: can't classify as buff/debuff; force full update
-                    UnitButton_UpdateBuffs(self, true)
-                    UnitButton_UpdateDebuffs(self, true)
-                    I.UpdateStatusIcon(self)
-                    return
+                if aura.isHelpful then
+                    buffsChanged = true
+                    self._buffs_cache[aura.auraInstanceID] = aura
+                end
+                if aura.isHarmful then
+                    debuffsChanged = true
+                    self._debuffs_cache[aura.auraInstanceID] = aura
                 end
             end
         end
@@ -1969,8 +1960,9 @@ local function UnitButton_UpdatePowerStates(self)
 
     self.states.power = UnitPower(unit)
     self.states.powerMax = UnitPowerMax(unit)
-    -- Midnight 12.0.0+: UnitPowerMax may return a secret number during restricted contexts
-    if not (Cell.isMidnight and F.IsAuraRestricted()) then
+    -- 12.0.5+: UnitPower/UnitPowerMax can return secrets in restricted contexts (arena pets,
+    -- enemy PvP units). Guard per-value — IsAuraRestricted is aura-scoped and misses these.
+    if not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(self.states.powerMax)) then
         if self.states.powerMax <= 0 then self.states.powerMax = 1 end
     end
 end
@@ -3377,7 +3369,11 @@ local function UnitButton_OnTick(self)
 
         if self.states.unit and self.states.displayedUnit then
             local displayedGuid = UnitGUID(self.states.displayedUnit)
-            if displayedGuid ~= self.__displayedGuid then
+            -- 12.0.5+: UnitGUID can return a secret in restricted contexts. Comparing a secret
+            -- against a plaintext cached GUID taints; skip the change-detection this tick.
+            -- The secure header still drives real unit-change events, so this is safe.
+            local displayedGuidReadable = not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(displayedGuid))
+            if displayedGuidReadable and displayedGuid ~= self.__displayedGuid then
                 -- NOTE: displayed unit entity changed
                 F.RemoveElementsExceptKeys(self.states, "unit", "displayedUnit")
                 self.__displayedGuid = displayedGuid
@@ -3388,7 +3384,8 @@ local function UnitButton_OnTick(self)
             end
 
             local guid = UnitGUID(self.states.unit)
-            if guid and guid ~= self.__unitGuid then
+            local guidReadable = not (Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid))
+            if guidReadable and guid and guid ~= self.__unitGuid then
                 -- print("guidChanged:", self:GetName(), self.states.unit, guid)
                 -- NOTE: unit entity changed
                 -- update Cell.vars.guids

--- a/Utilities/BuffTracker.lua
+++ b/Utilities/BuffTracker.lua
@@ -754,7 +754,7 @@ local function CheckUnit(unit, updateBtn)
 
     if UnitIsConnected(unit) and UnitIsVisible(unit) and not UnitIsDeadOrGhost(unit) then
         local guid = UnitGUID(unit)
-        -- 12.0.5+: secret GUIDs can't be used as table keys; LGI indexes its cache by GUID.
+        -- LGI indexes its cache by GUID; a secret GUID would throw on the table lookup.
         if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid) then return end
         local info = LGI:GetCachedInfo(guid)
         local spec = info and info.specId

--- a/Utilities/BuffTracker.lua
+++ b/Utilities/BuffTracker.lua
@@ -753,7 +753,10 @@ local function CheckUnit(unit, updateBtn)
     hasBuffFromMe[unit] = nil
 
     if UnitIsConnected(unit) and UnitIsVisible(unit) and not UnitIsDeadOrGhost(unit) then
-        local info = LGI:GetCachedInfo(UnitGUID(unit))
+        local guid = UnitGUID(unit)
+        -- 12.0.5+: secret GUIDs can't be used as table keys; LGI indexes its cache by GUID.
+        if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid) then return end
+        local info = LGI:GetCachedInfo(guid)
         local spec = info and info.specId
         local required = spec and requiredBuffs[spec]
 

--- a/Utilities/DeathReport.lua
+++ b/Utilities/DeathReport.lua
@@ -179,7 +179,7 @@ else
     local function OnUnitHealth(unit)
         if not unit then return end
         local guid = UnitGUID(unit)
-        -- 12.0.5+: GUIDs can be secret in restricted contexts; can't be used as table keys.
+        -- Secret GUIDs can't be used as table keys.
         if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid) then return end
         if UnitIsDeadOrGhost(unit) and not UnitIsFeignDeath(unit) then
             if guid and not reportedDead[guid] then

--- a/Utilities/DeathReport.lua
+++ b/Utilities/DeathReport.lua
@@ -178,8 +178,10 @@ else
 
     local function OnUnitHealth(unit)
         if not unit then return end
+        local guid = UnitGUID(unit)
+        -- 12.0.5+: GUIDs can be secret in restricted contexts; can't be used as table keys.
+        if Cell.isMidnight and F.IsSecretValue and F.IsSecretValue(guid) then return end
         if UnitIsDeadOrGhost(unit) and not UnitIsFeignDeath(unit) then
-            local guid = UnitGUID(unit)
             if guid and not reportedDead[guid] then
                 reportedDead[guid] = true
                 if not CheckSendLimit() then return end
@@ -188,7 +190,6 @@ else
             end
         else
             -- unit is alive again; allow future death reports
-            local guid = UnitGUID(unit)
             if guid then
                 reportedDead[guid] = nil
             end

--- a/Utilities/QuickAssist.lua
+++ b/Utilities/QuickAssist.lua
@@ -401,12 +401,14 @@ end
 
 local function QuickAssist_UpdateHealthMax(self)
     if not self.unit then return end
+    -- StatusBar:SetMinMaxValues accepts secret-wrapped values on Midnight (see UnitButton.lua:2398).
     self.healthBar:SetMinMaxValues(0, UnitHealthMax(self.unit))
 end
 
 local function QuickAssist_UpdateHealth(self)
     if not self.unit then return end
 
+    -- StatusBar:SetValue accepts secret-wrapped values on Midnight.
     self.healthBar:SetValue(UnitHealth(self.unit))
 
     if UnitIsDeadOrGhost(self.unit) then

--- a/Widgets/Widgets_IndicatorSettings.lua
+++ b/Widgets/Widgets_IndicatorSettings.lua
@@ -1395,14 +1395,8 @@ local function CreateSetting_PowerFormat(parent)
 
         widget.format = Cell.CreateDropdown(widget, 127)
         widget.format:SetPoint("TOPLEFT", 5, -20)
+        -- Percentage removed in 12.0.5: no power calc/curve API to derive percent on a secret.
         widget.format:SetItems({
-            {
-                ["text"] = "50%",
-                ["value"] = "percentage",
-                ["onClick"] = function()
-                    widget.func("percentage")
-                end,
-            },
             {
                 ["text"] = "25000",
                 ["value"] = "number",

--- a/Widgets/Widgets_IndicatorSettings.lua
+++ b/Widgets/Widgets_IndicatorSettings.lua
@@ -1395,8 +1395,14 @@ local function CreateSetting_PowerFormat(parent)
 
         widget.format = Cell.CreateDropdown(widget, 127)
         widget.format:SetPoint("TOPLEFT", 5, -20)
-        -- Percentage removed in 12.0.5: no power calc/curve API to derive percent on a secret.
         widget.format:SetItems({
+            {
+                ["text"] = "50%",
+                ["value"] = "percentage",
+                ["onClick"] = function()
+                    widget.func("percentage")
+                end,
+            },
             {
                 ["text"] = "25000",
                 ["value"] = "number",


### PR DESCRIPTION
## Problem
After the WoW 12.0.5 patch, Cell breaks on load and during gameplay with a cascade of errors:

1. **Static white health bars, no updates.** `C_UnitAuras.AddPrivateAuraAnchor` now requires a new `isContainer` field in its args table - the missing field throws during frame init, which cascades into `SetAttribute` failures in group headers and ultimately leaves every UnitButton half-initialized.
2. **`execution tainted by 'Cell'` taint errors** across Indicators/Custom.lua, Indicators/TargetedSpells.lua, and RaidFrames/UnitButton.lua. Patch 12.0.5 expanded the Secret Value surface: fields that previously returned secrets only when `F.IsAuraRestricted()` was true can now be secret in contexts where aura restrictions are NOT active (arena pets, enemy units in BGs, certain cast info).

## Root cause
r275 assumed Secret Values correlated with `IsAuraRestricted() / IsCooldownRestricted()` context flags - guarding at the context level rather than at the value level. Patch 12.0.5 decoupled those: `UnitGUID`, `UnitPowerMax`, `UnitCastingInfo` / `UnitChannelInfo` returns, and `auraInfo.sourceUnit` can now independently return secrets. Context-level guards miss these, and the subsequent comparison/arithmetic/table-index taints execution.

The wiki confirms the related behaviour changes in https://warcraft.wiki.gg/wiki/Patch_12.0.5/API_changes - notably the five `isHelpful`/`isHarmful`/`isRaid`/`isNameplateOnly`/`isFromPlayerOrPlayerPet` fields are now always non-secret, which this PR also takes advantage of by removing some now-dead fallbacks.

## Changes
- **`Cell.toc`** - Interface 120001 -> 120005 (I don't run Classic so I've left those alone).
- **`Indicators/Built-in.lua`** - Add `isContainer = false` to the `C_UnitAuras.AddPrivateAuraAnchor` args table (required in 12.0.5).
- **`Indicators/Custom.lua`** - Drop the `issecretvalue(auraInfo.isHelpful)` bailout (dead in 12.0.5); guard `auraInfo.sourceUnit` comparison with `F.IsValueNonSecret`.
- **`Indicators/TargetedSpells.lua`** - Bail in `CheckUnitCast` when `UnitCastingInfo` / `UnitChannelInfo` returns secret `spellId`, `startTimeMS`, `endTimeMS`, or `texture`.
- **`RaidFrames/UnitButton.lua`** - Guard both `UnitGUID` comparisons in `UnitButton_OnTick`; guard `powerMax` comparison in `UnitButton_UpdatePowerStates`; drop the classification-only "force full update" fallback in the incremental aura fast path (dead in 12.0.5).

## Testing
Tested live on 12.0.5 retail across:
- Solo / target dummy
- 5-man dungeon
- Raid (20-person group)
