### PR TITLE
feat(Vanilla/TBC): Shield Support for Vanilla and TBC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Libs/*
 !Libs/LibSpecData.lua
 !Libs/LibGroupInfo.lua
 !Libs/LibBadWords.lua
+!Libs/LibShields.lua
 !Libs/LoadLibs.xml
 !Libs/LoadLibs_Classic.xml
 !Libs/LibTranslit-1.0

--- a/Defaults/Appearance_Defaults.lua
+++ b/Defaults/Appearance_Defaults.lua
@@ -33,8 +33,8 @@ Cell.defaults.appearance = {
     ["healPrediction"] = {true, false, {1, 1, 1, 0.4}},
     ["healAbsorb"] = {Cell.isRetail or Cell.isMists, {1, 0.1, 0.1, 1}},
     ["healAbsorbInvertColor"] = false,
-    ["shield"] = {not (Cell.isTBC or Cell.isVanilla), {1, 1, 1, 0.4}},
-    ["overshield"] = {not (Cell.isTBC or Cell.isVanilla), {1, 1, 1, 1}},
+    ["shield"] = {{1, 1, 1, 0.4}},
+    ["overshield"] = {{1, 1, 1, 1}},
     ["overshieldReverseFill"] = false,
 }
 

--- a/Defaults/Layout_Defaults_TBC_Vanilla.lua
+++ b/Defaults/Layout_Defaults_TBC_Vanilla.lua
@@ -1,7 +1,7 @@
 local addonName, Cell = ...
 
 -- number of built-in indicators
-Cell.defaults.builtIns = 27
+Cell.defaults.builtIns = 28
 
 Cell.defaults.indicatorIndices = {
     ["nameText"] = 1,
@@ -20,17 +20,18 @@ Cell.defaults.indicatorIndices = {
     ["aggroBlink"] = 14,
     ["aggroBar"] = 15,
     ["aggroBorder"] = 16,
-    ["aoeHealing"] = 17,
-    ["externalCooldowns"] = 18,
-    ["defensiveCooldowns"] = 19,
-    ["allCooldowns"] = 20,
-    ["dispels"] = 21,
-    ["debuffs"] = 22,
-    ["raidDebuffs"] = 23,
-    ["targetedSpells"] = 24,
-    ["targetCounter"] = 25,
-    ["actions"] = 26,
-    ["missingBuffs"] = 27,
+    ["shieldBar"] = 17,
+    ["aoeHealing"] = 18,
+    ["externalCooldowns"] = 19,
+    ["defensiveCooldowns"] = 20,
+    ["allCooldowns"] = 21,
+    ["dispels"] = 22,
+    ["debuffs"] = 23,
+    ["raidDebuffs"] = 24,
+    ["targetedSpells"] = 25,
+    ["targetCounter"] = 26,
+    ["actions"] = 27,
+    ["missingBuffs"] = 28,
 }
 
 Cell.defaults.layout = {
@@ -314,13 +315,24 @@ Cell.defaults.layout = {
             ["thickness"] = 2,
         }, -- 16
         {
+            ["name"] = "Shield Bar",
+            ["indicatorName"] = "shieldBar",
+            ["type"] = "built-in",
+            ["enabled"] = false,
+            ["position"] = {"BOTTOMLEFT", nil, "BOTTOMLEFT", 0, 0},
+            ["frameLevel"] = 5,
+            ["height"] = 4,
+            ["color"] = {1, 1, 0, 1},
+            ["onlyShowOvershields"] = false,
+        }, -- 17
+        {
             ["name"] = "AoE Healing",
             ["indicatorName"] = "aoeHealing",
             ["type"] = "built-in",
             ["enabled"] = true,
             ["height"] = 10,
             ["color"] = {1, 1, 0},
-        }, -- 17
+        }, -- 18
         {
             ["name"] = "External Cooldowns",
             ["indicatorName"] = "externalCooldowns",
@@ -338,7 +350,7 @@ Cell.defaults.layout = {
                 {"Cell ".._G.DEFAULT, 11, "Outline", false, "BOTTOMRIGHT", 2, -1, {1, 1, 1}},
             },
             ["glowOptions"] = {"None", {0.95, 0.95, 0.32, 1}}
-        }, -- 18
+        }, -- 19
         {
             ["name"] = "Defensive Cooldowns",
             ["indicatorName"] = "defensiveCooldowns",
@@ -356,7 +368,7 @@ Cell.defaults.layout = {
                 {"Cell ".._G.DEFAULT, 11, "Outline", false, "BOTTOMRIGHT", 2, -1, {1, 1, 1}},
             },
             ["glowOptions"] = {"None", {0.95, 0.95, 0.32, 1}}
-        }, -- 19
+        }, -- 20
         {
             ["name"] = "Externals + Defensives",
             ["indicatorName"] = "allCooldowns",
@@ -374,7 +386,7 @@ Cell.defaults.layout = {
                 {"Cell ".._G.DEFAULT, 11, "Outline", false, "BOTTOMRIGHT", 2, -1, {1, 1, 1}},
             },
             ["glowOptions"] = {"None", {0.95, 0.95, 0.32, 1}}
-        }, -- 20
+        }, -- 21
         {
             ["name"] = "Dispels",
             ["indicatorName"] = "dispels",
@@ -394,7 +406,7 @@ Cell.defaults.layout = {
             ["highlightType"] = "gradient-half",
             ["iconStyle"] = "blizzard",
             ["orientation"] = "right-to-left",
-        }, -- 21
+        }, -- 22
         {
             ["name"] = "Debuffs",
             ["indicatorName"] = "debuffs",
@@ -414,7 +426,7 @@ Cell.defaults.layout = {
             },
             ["dispellableByMe"] = false,
             ["orientation"] = "left-to-right",
-        }, -- 22
+        }, -- 23
         {
             ["name"] = "Raid Debuffs",
             ["indicatorName"] = "raidDebuffs",
@@ -433,7 +445,7 @@ Cell.defaults.layout = {
             ["onlyShowTopGlow"] = false,
             ["orientation"] = "left-to-right",
             ["showTooltip"] = false,
-        }, -- 23
+        }, -- 24
         {
             ["name"] = "Targeted Spells",
             ["indicatorName"] = "targetedSpells",
@@ -447,7 +459,7 @@ Cell.defaults.layout = {
             ["num"] = 1,
             ["font"] = {"Cell ".._G.DEFAULT, 12, "Outline", false, "TOPRIGHT", 2, 1, {1, 1, 1}},
             ["orientation"] = "left-to-right",
-        }, -- 24
+        }, -- 25
         {
             ["name"] = "Target Counter",
             ["indicatorName"] = "targetCounter",
@@ -462,14 +474,14 @@ Cell.defaults.layout = {
                 ["pve"] = false,
                 ["pvp"] = true,
             },
-        }, -- 25
+        }, -- 26
         {
             ["name"] = "Actions",
             ["indicatorName"] = "actions",
             ["type"] = "built-in",
             ["enabled"] = true,
             ["speed"] = 1,
-        }, -- 26
+        }, -- 27
         {
             ["name"] = "Missing Buffs",
             ["indicatorName"] = "missingBuffs",
@@ -479,7 +491,7 @@ Cell.defaults.layout = {
             ["frameLevel"] = 10,
             ["size"] = {13, 13},
             ["orientation"] = "right-to-left",
-        }, -- 27
+        }, -- 28
     },
 }
 

--- a/Libs/LibShields.lua
+++ b/Libs/LibShields.lua
@@ -1,0 +1,266 @@
+---------------------------------------------------------------------
+-- File: Cell\Libs\LibShields.lua
+-- Description: Tracks absorb shield amounts for Vanilla/TBC Classic
+--              via combat log events. Supports multiple shield types
+--              with category-based grouping.
+-- Author: kamirendawkins (kamiren@dawkins.dev)
+-- Created: 2026-04-27
+-- Modified: 2026-04-27
+---------------------------------------------------------------------
+
+local addonName, Cell = ...
+
+local lib = {}
+Cell.LibShields = lib
+
+local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+
+-------------------------------------------------
+-- Shield Registry
+-- [spellId] = { category = "...", base = N }
+--   category: groups related ranks for querying
+--   base: estimated absorb amount (before +healing/talents)
+-------------------------------------------------
+local SHIELD_DATA = {
+    -- Power Word: Shield (Priest)
+    [17]    = { category = "powerWordShield", base = 44 },
+    [592]   = { category = "powerWordShield", base = 88 },
+    [600]   = { category = "powerWordShield", base = 158 },
+    [3747]  = { category = "powerWordShield", base = 234 },
+    [6065]  = { category = "powerWordShield", base = 301 },
+    [6066]  = { category = "powerWordShield", base = 381 },
+    [10898] = { category = "powerWordShield", base = 484 },
+    [10899] = { category = "powerWordShield", base = 605 },
+    [10900] = { category = "powerWordShield", base = 763 },
+    [10901] = { category = "powerWordShield", base = 942 },
+    [25217] = { category = "powerWordShield", base = 1125 },
+    [25218] = { category = "powerWordShield", base = 1265 },
+
+    -- Ice Barrier (Mage - Frost talent, self-only)
+    [11426] = { category = "iceBarrier", base = 438 },
+    [13031] = { category = "iceBarrier", base = 549 },
+    [13032] = { category = "iceBarrier", base = 678 },
+    [13033] = { category = "iceBarrier", base = 818 },
+    [27134] = { category = "iceBarrier", base = 925 },
+    [33405] = { category = "iceBarrier", base = 1075 },
+
+    -- Mana Shield (Mage, self-only)
+    [1463]  = { category = "manaShield", base = 120 },
+    [8494]  = { category = "manaShield", base = 210 },
+    [8495]  = { category = "manaShield", base = 300 },
+    [10191] = { category = "manaShield", base = 390 },
+    [10192] = { category = "manaShield", base = 480 },
+    [10193] = { category = "manaShield", base = 570 },
+    [27131] = { category = "manaShield", base = 715 },
+
+    -- Sacrifice (Warlock Voidwalker, applied to warlock)
+    [7812]  = { category = "sacrifice", base = 305 },
+    [19438] = { category = "sacrifice", base = 510 },
+    [19440] = { category = "sacrifice", base = 770 },
+    [19441] = { category = "sacrifice", base = 1095 },
+    [19442] = { category = "sacrifice", base = 1470 },
+    [19443] = { category = "sacrifice", base = 1905 },
+    [27273] = { category = "sacrifice", base = 2855 },
+
+    -- Fire Ward (Mage, self-only, fire damage only)
+    [543]   = { category = "fireWard", base = 165 },
+    [8457]  = { category = "fireWard", base = 290 },
+    [8458]  = { category = "fireWard", base = 470 },
+    [10223] = { category = "fireWard", base = 675 },
+    [10225] = { category = "fireWard", base = 875 },
+    [27128] = { category = "fireWard", base = 1125 },
+
+    -- Frost Ward (Mage, self-only, frost damage only)
+    [6143]  = { category = "frostWard", base = 165 },
+    [8461]  = { category = "frostWard", base = 290 },
+    [8462]  = { category = "frostWard", base = 470 },
+    [10177] = { category = "frostWard", base = 675 },
+    [28609] = { category = "frostWard", base = 875 },
+    [32796] = { category = "frostWard", base = 1125 },
+}
+
+-- Fast lookup set for SPELL_ABSORBED routing
+local SHIELD_SPELLS = {}
+for spellId in pairs(SHIELD_DATA) do
+    SHIELD_SPELLS[spellId] = true
+end
+
+-------------------------------------------------
+-- State
+-- shields[guid] = {
+--     [category] = {
+--         amount = N,      -- current remaining absorb
+--         max = N,         -- initial absorb value (estimate)
+--         spellId = N,     -- which rank is active
+--         sourceGUID = "", -- who cast it
+--     },
+-- }
+-------------------------------------------------
+local shields = {}
+
+-------------------------------------------------
+-- Callbacks
+-- Signature: function(guid, totalAbsorbs, changedCategory, info)
+--   guid            - unit GUID
+--   totalAbsorbs    - sum of all active shields on this GUID
+--   changedCategory - which shield type changed (e.g. "powerWordShield")
+--   info            - the category's current state table, or nil if removed
+-------------------------------------------------
+local callbacks = {}
+
+function lib:RegisterCallback(key, func)
+    callbacks[key] = func
+end
+
+function lib:UnregisterCallback(key)
+    callbacks[key] = nil
+end
+
+local function FireCallbacks(guid, changedCategory, info)
+    local total = lib:GetTotalAbsorbs(guid)
+    for _, func in pairs(callbacks) do
+        func(guid, total, changedCategory, info)
+    end
+end
+
+-------------------------------------------------
+-- Public API
+-------------------------------------------------
+
+--- Get total absorbs across all shield types for a GUID.
+--- @param guid string
+--- @return number
+function lib:GetTotalAbsorbs(guid)
+    local data = shields[guid]
+    if not data then return 0 end
+
+    local total = 0
+    for _, info in pairs(data) do
+        total = total + (info.amount or 0)
+    end
+    return total
+end
+
+--- Get absorb amount for a specific shield category.
+--- @param guid string
+--- @param category string e.g. "powerWordShield", "iceBarrier"
+--- @return number amount, number|nil max
+function lib:GetShieldAmount(guid, category)
+    local data = shields[guid]
+    if not data or not data[category] then return 0, nil end
+    return data[category].amount, data[category].max
+end
+
+--- Get all active shields for a GUID.
+--- @param guid string
+--- @return table|nil { [category] = { amount, max, spellId, sourceGUID } }
+function lib:GetAllShields(guid)
+    return shields[guid]
+end
+
+--- Check if a spell ID is a tracked shield.
+--- @param spellId number
+--- @return boolean
+function lib:IsShieldSpell(spellId)
+    return SHIELD_SPELLS[spellId] or false
+end
+
+--- Get the category for a shield spell ID.
+--- @param spellId number
+--- @return string|nil
+function lib:GetCategory(spellId)
+    local data = SHIELD_DATA[spellId]
+    return data and data.category
+end
+
+--- Reset all shield tracking for a specific GUID.
+--- @param guid string
+function lib:ResetGUID(guid)
+    if guid then
+        shields[guid] = nil
+    end
+end
+
+--- Wipe all tracked data.
+function lib:ResetAll()
+    wipe(shields)
+end
+
+-------------------------------------------------
+-- Combat Log Handler
+-------------------------------------------------
+local cleu = CreateFrame("Frame")
+cleu:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+
+cleu:SetScript("OnEvent", function()
+    local timestamp, subEvent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags,
+          destGUID, destName, destFlags, destRaidFlags,
+          arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22
+          = CombatLogGetCurrentEventInfo()
+
+    if subEvent == "SPELL_AURA_APPLIED" then
+        local shieldData = SHIELD_DATA[arg12]
+        if not shieldData then return end
+        if not Cell.funcs.IsFriend(destFlags) then return end
+
+        local category = shieldData.category
+        local baseAbsorb = shieldData.base or 0
+
+        if not shields[destGUID] then
+            shields[destGUID] = {}
+        end
+
+        shields[destGUID][category] = {
+            amount = baseAbsorb,
+            max = baseAbsorb,
+            spellId = arg12,
+            sourceGUID = sourceGUID,
+        }
+
+        FireCallbacks(destGUID, category, shields[destGUID][category])
+
+    elseif subEvent == "SPELL_ABSORBED" then
+        if not Cell.funcs.IsFriend(destFlags) then return end
+
+        local absorbSpellId, absorbAmount
+        if arg21 then -- spell damage
+            absorbSpellId, absorbAmount = arg19, arg22
+        else -- swing damage
+            absorbSpellId, absorbAmount = arg16, arg19
+        end
+
+        if not SHIELD_SPELLS[absorbSpellId] then return end
+
+        local shieldData = SHIELD_DATA[absorbSpellId]
+        local category = shieldData.category
+        local guidData = shields[destGUID]
+
+        if guidData and guidData[category] then
+            guidData[category].amount = guidData[category].amount - absorbAmount
+            if guidData[category].amount <= 0 then
+                guidData[category] = nil
+                if not next(guidData) then
+                    shields[destGUID] = nil
+                end
+            end
+        end
+
+        FireCallbacks(destGUID, category, guidData and guidData[category])
+
+    elseif subEvent == "SPELL_AURA_REMOVED" then
+        local shieldData = SHIELD_DATA[arg12]
+        if not shieldData then return end
+
+        local category = shieldData.category
+        local guidData = shields[destGUID]
+
+        if guidData then
+            guidData[category] = nil
+            if not next(guidData) then
+                shields[destGUID] = nil
+            end
+        end
+
+        FireCallbacks(destGUID, category, nil)
+    end
+end)

--- a/Libs/LoadLibs_Classic.xml
+++ b/Libs/LoadLibs_Classic.xml
@@ -13,6 +13,7 @@
     <Include file="LibSerialize\lib.xml"/>
     <Include file="LibDeflate\lib.xml"/>
     <Script file="LibBadWords.lua"/>
+    <Script file="LibShields.lua"/>
     <Include file="LibTranslit-1.0\LibTranslit-1.0.xml"/>
     <!-- <Script file="LibGroupInfo.lua"/> -->
     <!-- <Script file="LibRangeCheck-2.0\LibRangeCheck-2.0.lua"/> -->

--- a/Modules/Appearance/Appearance.lua
+++ b/Modules/Appearance/Appearance.lua
@@ -1498,7 +1498,6 @@ local function CreateUnitButtonStylePane()
         Cell.Fire("UpdateAppearance", "shields")
     end)
     shieldCB:SetPoint("TOPLEFT", absorbCB, "BOTTOMLEFT", 0, -28)
-    shieldCB:SetEnabled(not (Cell.isVanilla or Cell.isTBC))
 
     shieldColorPicker = Cell.CreateColorPicker(unitButtonPane, L["Shield Texture"], true, function(r, g, b, a)
         CellDB["appearance"]["shield"][2][1] = r
@@ -1523,7 +1522,6 @@ local function CreateUnitButtonStylePane()
         Cell.Fire("UpdateAppearance", "shields")
     end)
     oversCB:SetPoint("TOPLEFT", shieldCB, "BOTTOMLEFT", 0, -28)
-    oversCB:SetEnabled(not (Cell.isVanilla or Cell.isTBC))
 
     oversColorPicker = Cell.CreateColorPicker(unitButtonPane, L["Overshield Texture"], true, function(r, g, b, a)
         CellDB["appearance"]["overshield"][2][1] = r

--- a/Modules/Indicators/Indicators.lua
+++ b/Modules/Indicators/Indicators.lua
@@ -1648,6 +1648,7 @@ elseif Cell.isVanilla or Cell.isTBC then
         ["aggroBlink"] = {"enabled", "size", "position", "frameLevel"},
         ["aggroBorder"] = {"enabled", "thickness", "frameLevel"},
         ["aggroBar"] = {"enabled", "size", "position", "frameLevel"},
+        ["shieldBar"] = {"enabled", "checkbutton:onlyShowOvershields", "color-alpha", "height", "shieldBarPosition", "frameLevel"},
         ["aoeHealing"] = {"|cffb7b7b7"..L["Display a gradient texture when the unit receives a heal from your certain healing spells."], "enabled", "builtInAoEHealings", "customAoEHealings", "color", "height"},
         ["externalCooldowns"] = {L["Even if disabled, the settings below affect \"Externals + Defensives\" indicator"], "enabled", "builtInExternals", "customExternals", "durationVisibility", "checkbutton:showAnimation", "glowOptions", "size", "num:5", "orientation", "position", "frameLevel", "font1:stackFont", "font2:durationFont"},
         ["defensiveCooldowns"] = {L["Even if disabled, the settings below affect \"Externals + Defensives\" indicator"], "enabled", "builtInDefensives", "customDefensives", "durationVisibility", "checkbutton:showAnimation", "glowOptions", "size", "num:5", "orientation", "position", "frameLevel", "font1:stackFont", "font2:durationFont"},

--- a/RaidFrames/UnitButton_Vanilla.lua
+++ b/RaidFrames/UnitButton_Vanilla.lua
@@ -61,6 +61,7 @@ local UnitDetailedThreatSituation = UnitDetailedThreatSituation
 local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
 
 local barAnimationType, highlightEnabled, predictionEnabled
+local shieldEnabled, overshieldEnabled, overshieldReverseFillEnabled
 
 -------------------------------------------------
 -- unit button func declarations
@@ -1407,6 +1408,8 @@ end
 -------------------------------------------------
 -- functions
 -------------------------------------------------
+local LibShields = Cell.LibShields
+
 local function UnitButton_UpdateHealthStates(self, diff)
     local unit = self.states.displayedUnit
     local guid = self.states.guid
@@ -1417,7 +1420,11 @@ local function UnitButton_UpdateHealthStates(self, diff)
 
     self.states.health = health
     self.states.healthMax = healthMax
-    self.states.totalAbsorbs = 0
+    if guid then
+        self.states.totalAbsorbs = LibShields:GetTotalAbsorbs(guid)
+    else
+        self.states.totalAbsorbs = 0
+    end
 
     if healthMax == 0 then
         self.states.healthPercent = 0
@@ -2175,6 +2182,68 @@ if CELL_USE_LIBHEALCOMM then
 end
 
 -------------------------------------------------
+-- shields
+-------------------------------------------------
+UnitButton_UpdateShieldAbsorbs = function(self)
+    local unit = self.states.displayedUnit
+    if not unit then return end
+
+    UnitButton_UpdateHealthStates(self)
+
+    if self.states.totalAbsorbs > 0 then
+        local shieldPercent = self.states.totalAbsorbs / self.states.healthMax
+
+        if enabledIndicators["shieldBar"] then
+            if indicatorBooleans["shieldBar"] then
+                -- onlyShowOvershields
+                local overshieldPercent = (self.states.totalAbsorbs + self.states.health - self.states.healthMax) / self.states.healthMax
+                if overshieldPercent > 0 then
+                    self.indicators.shieldBar:Show()
+                    self.indicators.shieldBar:SetValue(overshieldPercent)
+                else
+                    self.indicators.shieldBar:Hide()
+                end
+            else
+                self.indicators.shieldBar:Show()
+                self.indicators.shieldBar:SetValue(shieldPercent)
+            end
+        else
+            self.indicators.shieldBar:Hide()
+        end
+
+        self.widgets.shieldBar:SetValue(shieldPercent, self.states.healthPercent)
+    else
+        self.indicators.shieldBar:Hide()
+        self.widgets.shieldBar:Hide()
+        self.widgets.overShieldGlow:Hide()
+        self.widgets.shieldBarR:Hide()
+        self.widgets.overShieldGlowR:Hide()
+    end
+end
+
+local function UnitButton_UpdatePowerWordShield(self, current, max, resetMax)
+    if not enabledIndicators["powerWordShield"] then return end
+
+    self.indicators.powerWordShield:UpdateShield(current, max, resetMax)
+end
+
+local function _UpdateShield(b)
+    UnitButton_UpdateShieldAbsorbs(b)
+    if enabledIndicators["powerWordShield"] then
+        local guid = b.states.guid
+        if guid then
+            local amount, max = LibShields:GetShieldAmount(guid, "powerWordShield")
+            b.indicators.powerWordShield:UpdateShield(amount, max, amount == 0)
+        end
+    end
+end
+
+-- Register LibShields callback to update unit buttons on shield changes
+LibShields:RegisterCallback("CellUnitButton", function(guid, totalAbsorbs, changedCategory, info)
+    F.HandleUnitButton("guid", guid, _UpdateShield)
+end)
+
+-------------------------------------------------
 -- cleu health updater
 -------------------------------------------------
 local cleuHealthUpdater = CreateFrame("Frame", "CellCleuHealthUpdater")
@@ -2242,6 +2311,7 @@ UnitButton_UpdateAll = function(self)
     UnitButton_UpdateTarget(self)
     UnitButton_UpdatePlayerRaidIcon(self)
     UnitButton_UpdateTargetRaidIcon(self)
+    UnitButton_UpdateShieldAbsorbs(self)
     UnitButton_UpdateInRange(self)
     UnitButton_UpdateRole(self)
     UnitButton_UpdateAssignment(self)
@@ -2378,10 +2448,12 @@ local function UnitButton_OnEvent(self, event, unit)
             UnitButton_UpdateHealthMax(self)
             UnitButton_UpdateHealth(self)
             UnitButton_UpdateHealPrediction(self)
+            UnitButton_UpdateShieldAbsorbs(self)
 
         elseif event == "UNIT_HEALTH" or event == "UNIT_HEALTH_FREQUENT" then
             UnitButton_UpdateHealth(self)
             UnitButton_UpdateHealPrediction(self)
+            UnitButton_UpdateShieldAbsorbs(self)
             -- UnitButton_UpdateStatusText(self)
 
         elseif event == "UNIT_HEAL_PREDICTION" then
@@ -2511,6 +2583,12 @@ local function UnitButton_OnAttributeChanged(self, name, value)
             end
 
             ResetAuraTables(self)
+
+            -- reset shields
+            local guid = UnitGUID(value)
+            if guid then
+                LibShields:ResetGUID(guid)
+            end
         end
     end
 end
@@ -2551,6 +2629,11 @@ local function UnitButton_OnHide(self)
     UnitButton_UnregisterEvents(self)
 
     ResetAuraTables(self)
+
+    -- reset shields
+    if self.__displayedGuid then
+        LibShields:ResetGUID(self.__displayedGuid)
+    end
 
     -- NOTE: update Cell.vars.guids
     -- print("hide", self.states.unit, self.__unitGuid, self.__unitName)
@@ -2676,7 +2759,22 @@ end
 
 function B.UpdateShields(button)
     predictionEnabled = CellDB["appearance"]["healPrediction"][1]
+    shieldEnabled = CellDB["appearance"]["shield"][1]
+    overshieldEnabled = CellDB["appearance"]["overshield"][1]
+    overshieldReverseFillEnabled = shieldEnabled and CellDB["appearance"]["overshieldReverseFill"]
+
+    button.widgets.shieldBar:SetVertexColor(unpack(CellDB["appearance"]["shield"][2]))
+    button.widgets.shieldBarR:SetVertexColor(unpack(CellDB["appearance"]["shield"][2]))
+    button.widgets.overShieldGlow:SetVertexColor(unpack(CellDB["appearance"]["overshield"][2]))
+    button.widgets.overShieldGlowR:SetVertexColor(unpack(CellDB["appearance"]["overshield"][2]))
+
     UnitButton_UpdateHealPrediction(button)
+    UnitButton_UpdateShieldAbsorbs(button)
+end
+
+-- shields
+function B.UpdateShield(button)
+    UnitButton_UpdateShieldAbsorbs(button)
 end
 
 function B.SetTexture(button, tex)
@@ -2697,6 +2795,102 @@ function B.UpdateColor(button)
     button:SetBackdropColor(0, 0, 0, CellDB["appearance"]["bgAlpha"])
 end
 
+local function ShieldBar_SetValue_Horizontal(self, shieldPercent, healthPercent)
+    local barWidth = self:GetParent():GetWidth()
+    if shieldPercent + healthPercent > 1 then -- overshield
+        local p = 1 - healthPercent
+        if p ~= 0 then
+            if shieldEnabled then
+                self:SetWidth(p * barWidth)
+                self:Show()
+            else
+                self:Hide()
+            end
+        else
+            self:Hide()
+        end
+
+        if overshieldReverseFillEnabled then
+            p = shieldPercent + healthPercent - 1
+            if p > healthPercent then p = healthPercent end
+            self.shieldBarR:SetWidth(p * barWidth)
+            self.shieldBarR:Show()
+            if overshieldEnabled then
+                self.overShieldGlowR:Show()
+            else
+                self.overShieldGlowR:Hide()
+            end
+            self.overShieldGlow:Hide()
+        else
+            if overshieldEnabled then
+                self.overShieldGlow:Show()
+            else
+                self.overShieldGlow:Hide()
+            end
+            self.shieldBarR:Hide()
+            self.overShieldGlowR:Hide()
+        end
+    else
+        if shieldEnabled then
+            self:SetWidth(shieldPercent * barWidth)
+            self:Show()
+        else
+            self:Hide()
+        end
+        self.shieldBarR:Hide()
+        self.overShieldGlow:Hide()
+        self.overShieldGlowR:Hide()
+    end
+end
+
+local function ShieldBar_SetValue_Vertical(self, shieldPercent, healthPercent)
+    local barHeight = self:GetParent():GetHeight()
+    if shieldPercent + healthPercent > 1 then -- overshield
+        local p = 1 - healthPercent
+        if p ~= 0 then
+            if shieldEnabled then
+                self:SetHeight(p * barHeight)
+                self:Show()
+            else
+                self:Hide()
+            end
+        else
+            self:Hide()
+        end
+
+        if overshieldReverseFillEnabled then
+            p = shieldPercent + healthPercent - 1
+            if p > healthPercent then p = healthPercent end
+            self.shieldBarR:SetHeight(p * barHeight)
+            self.shieldBarR:Show()
+            if overshieldEnabled then
+                self.overShieldGlowR:Show()
+            else
+                self.overShieldGlowR:Hide()
+            end
+            self.overShieldGlow:Hide()
+        else
+            if overshieldEnabled then
+                self.overShieldGlow:Show()
+            else
+                self.overShieldGlow:Hide()
+            end
+            self.shieldBarR:Hide()
+            self.overShieldGlowR:Hide()
+        end
+    else
+        if shieldEnabled then
+            self:SetHeight(shieldPercent * barHeight)
+            self:Show()
+        else
+            self:Hide()
+        end
+        self.shieldBarR:Hide()
+        self.overShieldGlow:Hide()
+        self.overShieldGlowR:Hide()
+    end
+end
+
 function B.SetOrientation(button, orientation, rotateTexture)
     local healthBar = button.widgets.healthBar
     local healthBarLoss = button.widgets.healthBarLoss
@@ -2705,6 +2899,10 @@ function B.SetOrientation(button, orientation, rotateTexture)
     local incomingHeal = button.widgets.incomingHeal
     local damageFlashTex = button.widgets.damageFlashTex
     local gapTexture = button.widgets.gapTexture
+    local shieldBar = button.widgets.shieldBar
+    local shieldBarR = button.widgets.shieldBarR
+    local overShieldGlow = button.widgets.overShieldGlow
+    local overShieldGlowR = button.widgets.overShieldGlowR
 
     gapTexture:SetColorTexture(unpack(CELL_BORDER_COLOR))
 
@@ -2776,6 +2974,31 @@ function B.SetOrientation(button, orientation, rotateTexture)
             end
         end
 
+        -- update shieldBar
+        shieldBar.SetValue = ShieldBar_SetValue_Horizontal
+        P.ClearPoints(shieldBar)
+        P.Point(shieldBar, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+        P.Point(shieldBar, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "BOTTOMRIGHT")
+
+        -- update shieldBarR
+        P.ClearPoints(shieldBarR)
+        P.Point(shieldBarR, "TOPRIGHT", healthBar:GetStatusBarTexture())
+        P.Point(shieldBarR, "BOTTOMRIGHT", healthBar:GetStatusBarTexture())
+
+        -- update overShieldGlow
+        P.ClearPoints(overShieldGlow)
+        P.Point(overShieldGlow, "TOPRIGHT")
+        P.Point(overShieldGlow, "BOTTOMRIGHT")
+        P.Width(overShieldGlow, 4)
+        F.RotateTexture(overShieldGlow, 0)
+
+        -- update overShieldGlowR
+        P.ClearPoints(overShieldGlowR)
+        P.Point(overShieldGlowR, "TOP", shieldBarR, "TOPLEFT", 0, 0)
+        P.Point(overShieldGlowR, "BOTTOM", shieldBarR, "BOTTOMLEFT", 0, 0)
+        P.Width(overShieldGlowR, 8)
+        F.RotateTexture(overShieldGlowR, 0)
+
         -- update damageFlashTex
         P.ClearPoints(damageFlashTex)
         P.Point(damageFlashTex, "TOPLEFT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
@@ -2833,6 +3056,31 @@ function B.SetOrientation(button, orientation, rotateTexture)
                 incomingHeal:Show()
             end
         end
+
+        -- update shieldBar
+        shieldBar.SetValue = ShieldBar_SetValue_Vertical
+        P.ClearPoints(shieldBar)
+        P.Point(shieldBar, "BOTTOMLEFT", healthBar:GetStatusBarTexture(), "TOPLEFT")
+        P.Point(shieldBar, "BOTTOMRIGHT", healthBar:GetStatusBarTexture(), "TOPRIGHT")
+
+        -- update shieldBarR
+        P.ClearPoints(shieldBarR)
+        P.Point(shieldBarR, "TOPLEFT", healthBar:GetStatusBarTexture())
+        P.Point(shieldBarR, "TOPRIGHT", healthBar:GetStatusBarTexture())
+
+        -- update overShieldGlow
+        P.ClearPoints(overShieldGlow)
+        P.Point(overShieldGlow, "TOPLEFT")
+        P.Point(overShieldGlow, "TOPRIGHT")
+        P.Height(overShieldGlow, 4)
+        F.RotateTexture(overShieldGlow, 90)
+
+        -- update overShieldGlowR
+        P.ClearPoints(overShieldGlowR)
+        P.Point(overShieldGlowR, "LEFT", shieldBarR, "BOTTOMLEFT", 0, 0)
+        P.Point(overShieldGlowR, "RIGHT", shieldBarR, "BOTTOMRIGHT", 0, 0)
+        P.Height(overShieldGlowR, 8)
+        F.RotateTexture(overShieldGlowR, 90)
 
         -- update damageFlashTex
         P.ClearPoints(damageFlashTex)
@@ -2950,6 +3198,11 @@ end
 -- statusText
 function B.UpdateStatusText(button)
     UnitButton_UpdateStatusText(button)
+end
+
+-- shields
+function B.UpdateShield(button)
+    UnitButton_UpdateShieldAbsorbs(button)
 end
 
 -- animation
@@ -3163,11 +3416,28 @@ function CellUnitButton_OnLoad(button)
     shieldBar:Hide()
     shieldBar.SetValue = DumbFunc
 
+    local shieldBarR = midLevelFrame:CreateTexture(name.."ShieldBarR", "ARTWORK", nil, -5)
+    button.widgets.shieldBarR = shieldBarR
+    shieldBarR:SetTexture("Interface\\AddOns\\Cell\\Media\\shield", "REPEAT", "REPEAT")
+    shieldBarR:SetHorizTile(true)
+    shieldBarR:SetVertTile(true)
+    shieldBarR:Hide()
+    shieldBar.shieldBarR = shieldBarR
+
     -- over-shield glow
     local overShieldGlow = midLevelFrame:CreateTexture(name.."OverShieldGlow", "ARTWORK", nil, -4)
     button.widgets.overShieldGlow = overShieldGlow
-    overShieldGlow:SetTexture("Interface\\RaidFrame\\Shield-Overshield")
+    overShieldGlow:SetTexture("Interface\\AddOns\\Cell\\Media\\overshield")
     overShieldGlow:Hide()
+    shieldBar.overShieldGlow = overShieldGlow
+
+    -- over-shield glow reversed
+    local overShieldGlowR = midLevelFrame:CreateTexture(name.."OverShieldGlowR", "ARTWORK", nil, -4)
+    button.widgets.overShieldGlowR = overShieldGlowR
+    overShieldGlowR:SetTexture("Interface\\AddOns\\Cell\\Media\\overshield_reversed")
+    -- overShieldGlowR:SetBlendMode("ADD")
+    overShieldGlowR:Hide()
+    shieldBar.overShieldGlowR = overShieldGlowR
 
     -- bar animation
     -- flash
@@ -3249,6 +3519,7 @@ function CellUnitButton_OnLoad(button)
     I.CreateAggroBorder(button)
     I.CreatePlayerRaidIcon(button)
     I.CreateTargetRaidIcon(button)
+    I.CreateShieldBar(button)
     I.CreateAoEHealing(button)
     -- I.CreateDefensiveCooldowns(button)
     -- I.CreateExternalCooldowns(button)


### PR DESCRIPTION
# Summary

Adds Support for Shields for Vanilla and TBC Versions.

Resolves #480

## TODO

* Performance Testing: This has only been tested in 5-Man content, while CLEU tracking is not typically performance intensive, this should still be tested in 25-Man content to ensure the existing performance of Cell is not adversely impacted.
* Triple Check LibShields logic to ensure full coverage of Vanilla and TBC is handled.

## Key Changes

* Allows for Shield and Over Shield Toggles.
* Includes `Shieldbar` BuiltIn for Vanilla and TBC using existing constructs.
* Implements Shield Indicators following existing patterns.
* Implements `LibShields` as an abstraction layer for managing Shield Logic and Value Fetching.


## Considerations

While replicating what is exactly present within the `UnitButton_Cata_Wrath` would suffice, it makes more sense to pull this logic into a dedicated Library that can be further enhanced to cover versions beyond Vanilla and TBC. This also allows for leaner code by reducing the amount of duplicated combat logic for versions where the existing APIs are insufficient for this feature.

## Challenges

Due to Vanilla and TBC APIs having no support for Shields and having any logic that can tell us what talents are currently active without intrusive, and throttled, API calls we have to assume that a given shield amount is the base amount. While we could assume every Priest takes 3/3 Improved Power Word: Shield it is best to not assume that will always be the case, present the value as the base amount, and allow cell to simply adjust the value as absorbed data rolls in.
