### PR TITLE
TBC Anni: "Coilfang: Serpentshrine Cavern" / "Tempest Keep"

### DIFF
--- a/RaidDebuffs/ExpansionData/ExpansionData.lua
+++ b/RaidDebuffs/ExpansionData/ExpansionData.lua
@@ -1949,7 +1949,7 @@ Cell_ExpansionData.data = {
         {
             ["id"] = 749,
             ["image"] = 608218,
-            ["name"] = "The Eye",
+            ["name"] = "Tempest Keep",
             ["bosses"] = {
                 {
                     ["id"] = 1573,

--- a/RaidDebuffs/ExpansionData/ExpansionData.lua
+++ b/RaidDebuffs/ExpansionData/ExpansionData.lua
@@ -1912,7 +1912,7 @@ Cell_ExpansionData.data = {
         {
             ["id"] = 748,
             ["image"] = 608199,
-            ["name"] = "Serpentshrine Cavern",
+            ["name"] = "Coilfang: Serpentshrine Cavern",
             ["bosses"] = {
                 {
                     ["id"] = 1567,


### PR DESCRIPTION
Naming needs to be exact due to 

```
Cell.snippetVars.instanceNameMapping[GetInstanceInfo()])
```

The hardcoded mapping is using `Serpentshrine Cavern` and in-game it is currently `Coilfang: Serpentshrine Cavern`. This mismatch prevents `Raid Debuffs` from being enabled for the instance.

```
/run print("instance =", GetInstanceInfo())
```


<img width="559" height="68" alt="image" src="https://github.com/user-attachments/assets/82eb1f44-4fe5-4c8e-9188-42c300422747" />


<img width="465" height="47" alt="image" src="https://github.com/user-attachments/assets/aec2e49e-0415-4ed5-840f-f14ff69a41f3" />


I'm not entirely sure of the origin of the data set. Whether this is exported somewhere (e.g from a particular client version). 